### PR TITLE
Gemini Compatibility + Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ This assumes you have Docker and Docker Compose installed.
 3.  **Edit the .env file with your specific configuration:**
     - Database settings: POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_NAME, POSTGRES_HOST
     - At least one LLM API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY)
-    - Set LLM_CHOICE to your preferred provider (CLAUDE, OPENAI, GEMINI)
+    - Set LLM_CHOICE to your preferred provider (`CLAUDE`, `OPENAI`, or `GEMINI`). To switch models after initial setup, update LLM_CHOICE in `.env` and do a full restart: `docker compose down && docker compose up` — a simple restart may not pick up the change.
 
 4.  **Build and run using Docker Compose:**
     ```bash
-    docker compose up -d 
+    docker compose up -d
     ```
 
 4. **Add a superuser:**
@@ -72,13 +72,20 @@ This assumes you have Docker and Docker Compose installed.
     docker compose down
     ```
 
-## Updating from main:
+## Updating (development):
 
-After pulling updates, rebuild and restart the web container. Migrations run automatically on startup.
+Pull the latest changes and rebuild. Migrations run automatically on startup.
 
 ```bash
 git pull origin main
-docker compose up --build -d web
+docker compose down && docker compose up --build -d
+```
+
+## Updating (production):
+
+```bash
+git pull origin main
+docker compose -f docker-compose-prod.yml down && docker compose -f docker-compose-prod.yml up --build -d
 ```
 
 ## Small-scale deployment:
@@ -95,7 +102,7 @@ docker compose up --build -d web
 3.  **Edit the .env file with your specific configuration:**
     - Database settings: POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_NAME, POSTGRES_HOST
     - At least one LLM API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY)
-    - Set LLM_CHOICE to your preferred provider (CLAUDE, OPENAI, GEMINI)
+    - Set LLM_CHOICE to your preferred provider (`CLAUDE`, `OPENAI`, or `GEMINI`). To switch models after initial setup, update LLM_CHOICE in `.env` and do a full restart: `docker compose down && docker compose -f docker-compose-prod.yml up` — a simple restart may not pick up the change.
     - Optional: Google OAuth credentials (GOOGLE_OAUTH2_CLIENT_ID, GOOGLE_OAUTH2_CLIENT_SECRET)
     - Optional: Email access permissions (ALLOWED_EMAIL_DOMAINS, ALLOWED_EMAIL_ADDRESSES). Required if OAuth is to be used.
     - Set HOST_NAME for your domain or use 'localhost' for development

--- a/aquillm/aquillm/apps.py
+++ b/aquillm/aquillm/apps.py
@@ -4,12 +4,13 @@ from django.template import Engine, Context
 import cohere
 import openai
 import anthropic
-import google.generativeai as genai
+import google.generativeai as genai  # older google SDK — kept for OCR/image features already using it
+from google import genai as google_genai  # NEW: newer google-genai SDK used by GeminiInterface for chat
 from os import getenv
 from typing import TypedDict
 
 
-from .llm import LLMInterface, ClaudeInterface, OpenAIInterface
+from .llm import LLMInterface, ClaudeInterface, OpenAIInterface, GeminiInterface  # GeminiInterface added for Gemini backend support
 from .settings import DEBUG
 RAG_PROMPT_STRING = """
 <context>
@@ -82,6 +83,7 @@ class AquillmConfig(AppConfig):
             aws_access_key=getenv('AWS_ACCESS_KEY_ID'),
             aws_secret_key=getenv('AWS_SECRET_ACCESS_KEY')
         )
+        self.google_genai_client = google_genai.Client(api_key=getenv('GEMINI_API_KEY'))  # Gemini API client, initialized at startup regardless of LLM_CHOICE so it's available even when not the primary LLM
         self.get_embedding = get_embedding_func(self.cohere_client)
         llm_choice = getenv('LLM_CHOICE', self.default_llm)
         if llm_choice == 'CLAUDE':
@@ -96,6 +98,8 @@ class AquillmConfig(AppConfig):
             self.llm_interface = OpenAIInterface(openai.AsyncOpenAI(base_url='http://ollama:11434/v1/'), "llama3.2")
         elif llm_choice == 'GPT-OSS':
             self.llm_interface = OpenAIInterface(openai.AsyncOpenAI(base_url='http://ollama:11434/v1/'), "gpt-oss:120b")
+        elif llm_choice == 'GEMINI':  # set LLM_CHOICE=GEMINI in .env to use Google Gemini as the chat backend
+            self.llm_interface = GeminiInterface(self.google_genai_client, model='gemini-2.5-flash')  # gemini-2.5-flash is the faster/cheaper variant; swap model= here to use gemini-2.5-pro etc.
         else:
             raise ValueError(f"Invalid LLM choice: {llm_choice}")
 

--- a/aquillm/aquillm/llm.py
+++ b/aquillm/aquillm/llm.py
@@ -18,6 +18,8 @@ from django.core import signing
 from json import loads
 
 from tiktoken import encoding_for_model
+from google import genai as google_genai  # Google Gemini client library — aliased to avoid clash with the older google.generativeai import
+from google.genai import types as genai_types  # Gemini request/response data classes (Content, Part, Tool, FunctionDeclaration, etc.)
 
 import uuid
 if DEBUG:
@@ -346,6 +348,7 @@ class LLMInterface(ABC):
             sdk_args = {**(self.base_args | tools |
                                                     {'system': system_prompt,
                                                     'messages': message_dicts,
+                                                    'messages_pydantic': messages_for_bot,  # Pydantic objects passed alongside rendered dicts so GeminiInterface can build proper FunctionCall/FunctionResponse parts; Claude and OpenAI strip this out with kwargs.pop()
                                                     'max_tokens': max_tokens})}
             #if DEBUG:
                 #print("LLM called with the following args:")
@@ -362,7 +365,7 @@ class LLMInterface(ABC):
                             **response.tool_call)
             if DEBUG:
                 print("Response from LLM:")
-                pp(new_msg.model_dump)
+                pp(new_msg.model_dump())  # bug fix: was model_dump without () — printed the method reference rather than the actual dict
 
             return conversation + [new_msg], 'changed'
 
@@ -384,7 +387,7 @@ class LLMInterface(ABC):
 
 class ClaudeInterface(LLMInterface):
 
-    base_args: dict = {'model': 'claude-3-7-sonnet-latest'}
+    base_args: dict = {'model': 'claude-sonnet-4-6'}  # updated from 'claude-3-7-sonnet-latest' to current model name
 
     @override
     def __init__(self, anthropic_client, model_override=None):
@@ -394,6 +397,8 @@ class ClaudeInterface(LLMInterface):
 
     @override
     async def get_message(self, *args, **kwargs) -> LLMResponse:
+        kwargs.pop('messages_pydantic', None)  # Gemini needs the raw Pydantic objects; Claude uses the rendered 'messages' dicts and would reject this unknown kwarg
+        kwargs.pop('thinking_budget', None)  # Gemini-only concept, ignored here
         response = await self.client.messages.create(**kwargs)
         if DEBUG:
             print("Claude SDK Response:")
@@ -413,12 +418,12 @@ class ClaudeInterface(LLMInterface):
             'tool_call_input' : tool_block.input,
         } if tool_block else {}
         
-        return LLMResponse(text=text_block.text,
-                           tool_call=tool_call, 
-                           stop_reason=response.stop_reason, 
-                           input_usage=response.usage.input_tokens, 
+        return LLMResponse(text=text_block.text if text_block else None,  # guard added: Claude can return a tool-call-only response with no text block; previously would crash
+                           tool_call=tool_call,
+                           stop_reason=response.stop_reason,
+                           input_usage=response.usage.input_tokens,
                            output_usage=response.usage.output_tokens,
-                           model=self.base_args['model'])
+                           model=self.base_args['model'])  # model name included so it gets stored in the database Message.model field
 
     @override
     async def token_count(self, conversation: Conversation, new_message: Optional[str] = None) -> int:
@@ -471,7 +476,8 @@ class OpenAIInterface(LLMInterface):
 
     @override
     async def get_message(self, *args, **kwargs) -> LLMResponse:
-
+        kwargs.pop('messages_pydantic', None)  # Gemini needs the raw Pydantic objects; OpenAI uses the rendered 'messages' dicts and would reject this unknown kwarg
+        kwargs.pop('thinking_budget', None)  # Gemini-only concept, ignored here
         arguments = {"model": self.base_args['model'],
                     "messages": [{"role": "developer", "content": kwargs.pop('system')}] + kwargs.pop('messages')}
 
@@ -499,7 +505,7 @@ class OpenAIInterface(LLMInterface):
                            stop_reason=response.choices[0].finish_reason,
                            input_usage=response.usage.prompt_tokens,
                            output_usage=response.usage.completion_tokens,
-                           model=self.base_args['model']
+                           model=self.base_args['model']  # added so model name gets stored in the database Message.model field (was missing before)
                            )
                         
     @override 
@@ -511,14 +517,258 @@ class OpenAIInterface(LLMInterface):
     
     
 class GeminiInterface(LLMInterface):
-    
+    """
+    LLM interface for Google Gemini models.
+    Translates between the app's internal message/tool format and the google-genai SDK format.
+    """
+    base_args: dict = {'model': 'gemini-2.5-flash'}
+
     @override
-    def __init__(self, google_client):
+    def __init__(self, google_client, model: str = 'gemini-2.5-flash'):
+        """Store the Gemini client and which model to use."""
         self.client = google_client
+        self.base_args = {'model': model}
 
-    
+    def _transform_tools(self, tools: list[dict]) -> genai_types.Tool:
+        """
+        Convert tool definitions from the app's internal format (Anthropic-style dicts)
+        into a Gemini Tool object containing FunctionDeclarations.
+        The input_schema passes through directly since Gemini accepts the same JSON schema format.
+        """
+        return genai_types.Tool(
+            function_declarations=[
+                genai_types.FunctionDeclaration(
+                    name=tool['name'],
+                    description=tool['description'],
+                    parametersJsonSchema=tool['input_schema'],
+                ) for tool in tools
+            ]
+        )
 
+    def _convert_messages(self, messages: list[dict]) -> list[genai_types.Content]:
+        """
+        Convert a list of rendered message dicts into Gemini Content objects using plain text.
+        Used only by token_count(), where approximate counts are acceptable.
+        For actual API calls, use _convert_pydantic_messages() instead.
+        """
+        contents = []
+        for msg in messages:
+            role = 'model' if msg['role'] == 'assistant' else 'user'
+            contents.append(genai_types.Content(
+                role=role,
+                parts=[genai_types.Part.from_text(text=msg['content'])]
+            ))
+        return contents
 
+    def _convert_pydantic_messages(self, messages: list) -> list[genai_types.Content]:
+        """
+        Convert Pydantic message objects into Gemini Content objects, using proper
+        FunctionCall and FunctionResponse parts for tool call history.
+
+        This gives Gemini a structured view of prior tool calls so it can:
+        - Properly attribute tool results to the correct function call
+        - Make better follow-up decisions (e.g. search again vs answer)
+
+        ToolMessages with for_whom='user' are already filtered out before this is called.
+        """
+        contents = []
+        for msg in messages:
+            if isinstance(msg, AssistantMessage):
+                parts = []
+                # Include real text if the model said something (not just the tool-call placeholder)
+                if msg.content and msg.content != "** Empty Message, tool call **":
+                    parts.append(genai_types.Part.from_text(text=msg.content))
+                # Include a FunctionCall part if the model called a tool
+                if msg.tool_call_id:
+                    parts.append(genai_types.Part(
+                        function_call=genai_types.FunctionCall(
+                            name=msg.tool_call_name,
+                            args=msg.tool_call_input or {},
+                        )
+                    ))
+                if not parts:  # fallback: should not normally happen
+                    parts = [genai_types.Part.from_text(text=msg.content or '')]
+                contents.append(genai_types.Content(role='model', parts=parts))
+            elif isinstance(msg, ToolMessage):
+                # Tool result — pass back as a structured FunctionResponse
+                contents.append(genai_types.Content(
+                    role='user',
+                    parts=[genai_types.Part(
+                        function_response=genai_types.FunctionResponse(
+                            name=msg.tool_name,
+                            response={'output': msg.content},
+                        )
+                    )]
+                ))
+            else:
+                # UserMessage
+                contents.append(genai_types.Content(
+                    role='user',
+                    parts=[genai_types.Part.from_text(text=msg.content or '')]
+                ))
+        return contents
+
+    def _build_tool_config(self, tool_choice: dict) -> genai_types.ToolConfig:
+        """
+        Convert the app's tool_choice setting into a Gemini ToolConfig object.
+        'auto'  -> LLM decides whether to call a tool
+        'any'   -> LLM must call some tool
+        'tool'  -> LLM must call a specific named tool (enforced via allowedFunctionNames)
+        """
+        mode_map = {'auto': 'AUTO', 'any': 'ANY', 'tool': 'ANY'}
+        mode = mode_map.get(tool_choice['type'], 'AUTO')
+        # When a specific tool is required, restrict Gemini to only that function
+        if tool_choice['type'] == 'tool':
+            allowed = [tool_choice['name']]
+        else:
+            allowed = None
+        return genai_types.ToolConfig(
+            functionCallingConfig=genai_types.FunctionCallingConfig(
+                mode=mode,
+                allowedFunctionNames=allowed
+            )
+        )
+
+    @override
+    async def get_message(self, *args, **kwargs) -> LLMResponse:
+        """
+        Main method: send the conversation to Gemini and return a standardised LLMResponse.
+        Handles both plain text replies and tool call responses.
+        """
+        # Note: the google-genai SDK uses camelCase in constructors (e.g. GenerateContentConfig)
+        # but snake_case when reading attributes back from responses (e.g. usage_metadata).
+        # Pull each expected argument out of kwargs by name
+        system = kwargs.pop('system')
+        messages = kwargs.pop('messages')  # rendered dicts — fallback for callers that don't provide Pydantic objects
+        messages_pydantic = kwargs.pop('messages_pydantic', None)  # provided by complete(), not by set_name()
+        max_tokens = kwargs.pop('max_tokens')
+        tools = kwargs.pop('tools', None)        # optional - not all conversations use tools
+        tool_choice = kwargs.pop('tool_choice', None)  # optional - comes with tools
+        thinking_budget = kwargs.pop('thinking_budget', None)  # optional - set to 0 to disable thinking
+
+        # Use Pydantic objects when available (proper FunctionCall/FunctionResponse parts).
+        # Fall back to plain text dicts for callers like set_name() that don't have Pydantic objects.
+        if messages_pydantic is not None:
+            contents = self._convert_pydantic_messages(messages_pydantic)
+        else:
+            contents = self._convert_messages(messages)
+
+        # Only prepare tool objects if this conversation has tools
+        if tools:
+            gemini_tools = [self._transform_tools(tools)]
+            tool_config = self._build_tool_config(tool_choice)
+        else:
+            gemini_tools = None
+            tool_config = None
+
+        # Bundle system prompt, token limit, and tool settings into one config object
+        # thinkingConfig is only set when explicitly requested (e.g. thinkingBudget=0 disables
+        # thinking entirely for simple tasks like title generation, saving tokens)
+        thinking_config = genai_types.ThinkingConfig(thinkingBudget=thinking_budget) if thinking_budget is not None else None
+        config = genai_types.GenerateContentConfig(
+            systemInstruction=system,
+            maxOutputTokens=max_tokens,
+            tools=gemini_tools,
+            toolConfig=tool_config,
+            thinkingConfig=thinking_config,
+        )
+
+        # The actual API call to Gemini - await means we wait for the response
+        response = await self.client.aio.models.generate_content(
+            model=self.base_args['model'],
+            contents=contents,
+            config=config,
+        )
+
+        # Check if Gemini decided to call a tool instead of (or as well as) replying with text
+        function_calls = response.function_calls
+        if function_calls:
+            fc = function_calls[0]
+            # Gemini doesn't always provide a tool call ID, so generate one if missing
+            if fc.id:
+                tool_call_id = fc.id
+            else:
+                tool_call_id = str(uuid.uuid4())
+            if fc.args:
+                tool_call_input = fc.args
+            else:
+                tool_call_input = {}
+            tool_call = {
+                'tool_call_id': tool_call_id,
+                'tool_call_name': fc.name,
+                'tool_call_input': tool_call_input,
+            }
+            stop_reason = 'tool_use'
+        else:
+            # No tool call - plain text reply
+            tool_call = {}
+            stop_reason = 'end_turn'
+
+        # Extract token usage for cost tracking (usage_metadata may be None in rare cases)
+        usage = response.usage_metadata
+        if usage:
+            input_tokens = usage.prompt_token_count or 0
+            # candidates_token_count can be None for thinking models (e.g. gemini-2.5-flash)
+            output_tokens = usage.candidates_token_count or 0
+        else:
+            input_tokens = 0
+            output_tokens = 0
+
+        # response.text raises ValueError when the response has no text parts (e.g. tool-call-only
+        # responses). Catch it and return None so the caller handles it gracefully.
+        try:
+            text = response.text
+        except (ValueError, AttributeError):
+            text = None
+
+        # Return a standardised LLMResponse that the rest of the app knows how to handle
+        return LLMResponse(
+            text=text,
+            tool_call=tool_call,       # empty dict if no tool call
+            stop_reason=stop_reason,
+            input_usage=input_tokens,
+            output_usage=output_tokens,
+            model=self.base_args['model'],
+        )
+
+    @override
+    async def token_count(self, conversation: Conversation, new_message: Optional[str] = None) -> int:
+        """
+        Count the total tokens in the conversation using Gemini's token counting API.
+        Optionally includes a new message the user is about to send.
+        Used by the app to check if the conversation is approaching the model's token limit.
+        """
+        # Filter out tool result messages intended for the user UI, not the LLM
+        messages_for_bot = []
+        for message in conversation:
+            if isinstance(message, ToolMessage) and message.for_whom == 'user':
+                pass  # skip - this message is for display only, not for the LLM
+            else:
+                messages_for_bot.append(message)
+
+        # If a new user message was provided, include it in the count
+        if new_message:
+            new_user_message = UserMessage(content=new_message)
+            all_messages = messages_for_bot + [new_user_message]
+        else:
+            all_messages = messages_for_bot
+
+        # Render each message to a plain dict, then convert to Gemini's format
+        rendered = []
+        for message in all_messages:
+            rendered.append(message.render(include={'role', 'content'}))
+        contents = self._convert_messages(rendered)
+
+        # Call Gemini's token counting endpoint - returns an exact count
+        response = await self.client.aio.models.count_tokens(
+            model=self.base_args['model'],
+            contents=contents,
+        )
+
+        if response.total_tokens:
+            return response.total_tokens
+        else:
+            return 0
 
 
 @llm_tool(

--- a/aquillm/aquillm/models.py
+++ b/aquillm/aquillm/models.py
@@ -819,9 +819,13 @@ class WSConversation(models.Model):
         first_two_messages = str(first_two)
 
         # Build kwargs compatible with the LLM interface
+        # thinking_budget=0 disables Gemini 2.5's internal reasoning for this simple task —
+        # without it, thinking tokens eat into the maxOutputTokens budget, truncating the title.
+        # Claude and OpenAI silently ignore thinking_budget.
         llm_args = {
             **llm_interface.base_args,  # Include base args (model, etc.)
             'max_tokens': 30,
+            'thinking_budget': 0,
             'system': system_prompt,
             'messages': [{'role': 'user', 'content': first_two_messages}]
         }
@@ -833,6 +837,8 @@ class WSConversation(models.Model):
             return response.text
 
         title_text = get_title()
+        if title_text:
+            title_text = title_text.strip().strip('"').strip("'").strip('*')  # Gemini (and sometimes Claude) wraps titles in quotes or asterisks; strip them so the UI title looks clean
         self.name = title_text if title_text else 'Conversation'
         self.save()
 

--- a/aquillm/chat/consumers.py
+++ b/aquillm/chat/consumers.py
@@ -38,7 +38,7 @@ class ChatRef:
 def get_vector_search_func(user: User, col_ref: CollectionsRef): 
     @llm_tool(
         param_descs={"search_string": "The string to search by. Often it helps to phrase it as a question. ",
-                     "top_k": "The number of results to return. Start low and increase if the desired information is not found. Go no higher than about 15."},
+                     "top_k": "The number of results to return. Start with 5 for simple questions, 8-10 for broad or multi-part questions. Increase if the desired information is not found. Go no higher than 15."},  # updated from vague "start low" to give Gemini/Claude more concrete starting guidance
         required=['search_string', 'top_k'],
         for_whom='assistant'
 
@@ -102,7 +102,7 @@ def get_whole_document_func(user: User, chat_ref: ChatRef) -> LLMTool:
 def get_search_single_document_func(user: User) -> LLMTool:
     @llm_tool(
         for_whom='assistant',
-        required=['doc_id', 'query'],
+        required=['doc_id', 'search_string', 'top_k'],  # bug fix: was ['doc_id', 'query'] — 'query' doesn't match any actual param name so the LLM couldn't satisfy the required constraint
         param_descs={'doc_id': 'UUID (as a string) of the document to search.',
                      'search_string': 'String to search the contents of the document by.',
                      'top_k': 'Number of search results to return.'}
@@ -120,9 +120,7 @@ def get_search_single_document_func(user: User) -> LLMTool:
         _,_,results = TextChunk.text_chunk_search(search_string, top_k, [doc])
         ret = {"result": {f"[Result {i+1}] -- {chunk.document.title} chunk #: {chunk.chunk_number} chunk_id:{chunk.id}": chunk.content for i, chunk in enumerate(results)}}
         return ret
-    
-    return search_single_document
-    
+
     return search_single_document
 def get_more_context_func(user: User) -> LLMTool:
     @llm_tool(
@@ -156,7 +154,7 @@ def get_more_context_func(user: User) -> LLMTool:
 def get_sky_subtraction_func(chat_consumer: 'ChatConsumer') -> LLMTool:
     @llm_tool(
         for_whom='assistant',
-        required=['object', 'sky'],
+        required=['object_id', 'sky_id'],  # bug fix: was ['object', 'sky'] — didn't match the actual param names object_id and sky_id so the LLM thought they were optional
         param_descs={'object_id': 'The file ID of the FITS file containing the object to subtract the sky from',
                      'sky_id': 'The file ID of the FITS file of the sky to subtract from the object'}
     )
@@ -198,7 +196,7 @@ def get_sky_subtraction_func(chat_consumer: 'ChatConsumer') -> LLMTool:
 def get_flat_fielding_func(chat_consumer: 'ChatConsumer') -> LLMTool:
     @llm_tool(
         for_whom='assistant',
-        required=['science', 'flat'],
+        required=['science_id', 'flat_id'],  # bug fix: was ['science', 'flat'] — same issue as sky_subtraction, param names didn't match
         param_descs={
             'science_id': 'The file ID of the FITS image to be flat-field corrected',
             'flat_id': 'The file ID of the flat-field FITS image to use for correction'
@@ -249,7 +247,7 @@ def get_flat_fielding_func(chat_consumer: 'ChatConsumer') -> LLMTool:
 def get_point_source_detection_func(chat_consumer: 'ChatConsumer') -> LLMTool:
     @llm_tool(
         for_whom='assistant',
-        required=['image'],
+        required=['image_id'],  # bug fix: was ['image'] — didn't match actual param name image_id
         param_descs={
             'image_id': 'The file ID of the sky-subtracted and flat-fielded FITS image to run source detection on.'
         }


### PR DESCRIPTION
### Add Google Gemini as a supported LLM backend - closes #53 

AquiLLM already supported Claude and OpenAI as chat backends. This PR adds Google Gemini as a third option via LLM_CHOICE=GEMINI, and fixes a bug where OpenAI model names weren't being saved to the message table.

### Background

AquiLLM has an abstraction layer so the rest of the app doesn't care which AI provider it's talking to — each provider has a subclass that handles the translation (i.e ClaudeInterface, OpenAIInterface). This PR implements GeminiInterface, which was previously an empty stub.

### What changed

Gemini backend (llm.py, apps.py): Gemini's API has a different shape than Claude/OpenAI, so several translation steps were needed:

1) **Tool Definitions:**

AquiLLM can give the LLM access to tools like document search. Each provider has its own format for describing what tools are available. The transform_tools() function converts to Gemini's expected format.

2) **Tool call history:** 

When the LLM calls a tool the result gets added to the conversation history so the LLM knows what it already searched and what came back. Every provider needs this history, but Gemini requires it in a specific structured format rather than just the text of what happened. The convert_pydantic_messages() function builds the history in that format before sending it to Gemini.

3) **Thinking Mode:** 

Gemini 2.5 can do internal reasoning before replying, and does so by default. This uses up part of the token budget. For short tasks like generating a conversation title, its thinking mode was causing it to consume the entire title token budget before producing any output, resulting in truncated titles. Thinking mode is now disabled for title generation. 

4) **Error handling:**  

When the LLM's response contains only a tool call and no text, reading the text from that response throws an exception in Gemini's SDK, crashing the app. The fix wraps that read in a try/except so it returns None instead.

5) **Compatibility fixes:** (llm.py): 

Some data that Gemini needs flows through code shared by all three providers. Claude and OpenAI are updated to ignore the Gemini-specific fields they don't need.

6) **Title generation fixes** (models.py)

 Beyond the thinking mode fix above, Gemini sometimes wraps generated titles in quotes or asterisks. These are stripped before saving so the UI title looks clean.

7) **Tool schema bug fixes** (consumers.py):

Each tool the LLM can call has a list of parameters it's required to provide. Several of these lists had parameter names that didn't match the actual function signatures, so the LLM would sometimes skip inputs it was supposed to fill in. Gemini's stricter validation caught these. Fixed in the document search, sky subtraction, flat fielding, and point source detection tools.

8) **OpenAI model name fix:** (llm.py)  

OpenAI model names weren't being saved to the database alongside messages, even though Claude's were. Closes #52.

9) **README Update:**

Minor update to README to make docker rebuild instructions better, it now addresses both production and dev use cases when pulling updates from main. It also has additional instructions for how to restart after switching LLM providers.

10) **Claude model update** (llm.py):

ClaudeInterface was hardcoded to claude-3-7-sonnet-latest, which was recently sunsetted by Anthropic and started returning errors. Updated to claude-sonnet-4-6.

How to use
Add GEMINI_API_KEY to .env, set LLM_CHOICE=GEMINI, and do a full docker compose down && docker compose up --build -d. A full restart is required because the LLM client is initialized once at startup.

_Note:_ The existing Gemini API key in the .env we were given, does not work. In order to test Gemini compatibility, you will have to put your own key in the .env file. 