### PR TITLE
Fix: refresh collection file list after document upload

### DIFF
--- a/react/src/components/CollectionView.tsx
+++ b/react/src/components/CollectionView.tsx
@@ -583,6 +583,7 @@ const CollectionView: React.FC<CollectionViewProps> = ({ collectionId, onBack })
         ingestWebpageUrl={window.apiUrls.api_ingest_webpage}
         ingestHandwrittenUrl={window.apiUrls.api_ingest_handwritten_notes}
         collectionId={collectionId}
+        onUploadSuccess={fetchCollectionData} // Re-fetch the collection file list when a document is uploaded
       />
 
       <div className="relative flex items-center mb-[24px]"> 

--- a/react/src/components/IngestRow.tsx
+++ b/react/src/components/IngestRow.tsx
@@ -17,6 +17,7 @@ interface IngestRowsContainerProps {
   ingestWebpageUrl: string;
   ingestHandwrittenUrl: string;
   collectionId: string;
+  onUploadSuccess?: () => void; // Optional callback to notify parent when a document is successfully uploaded
 }
 
 interface IngestRowData {
@@ -408,6 +409,7 @@ const IngestRowsContainer: React.FC<IngestRowsContainerProps> = ({
   ingestWebpageUrl,
   ingestHandwrittenUrl,
   collectionId,
+  onUploadSuccess, // Destructure the callback so it's accessible in handleSubmit
 }) => {
   const [rows, setRows] = useState<IngestRowData[]>([
     {
@@ -579,6 +581,7 @@ const IngestRowsContainer: React.FC<IngestRowsContainerProps> = ({
            } else {
              // Standard success handling for other types or synchronous responses
              setSubmissionStatus((prev) => ({ ...prev, [row.id]: "success" }));
+             onUploadSuccess?.(); // Notify parent to refresh the file list; ?. makes this a no-op if prop not provided
              // Clear inputs on standard success
              updateRow(row.id, {
                pdfTitle: "",


### PR DESCRIPTION
When a user uploaded a document to a collection, it appeared in the Ingestion Dashboard but not in the Browse file list, the list only updated after a manual page refresh.

Added an onUploadSuccess callback prop to IngestRowsContainer that fires after a successful upload, wired to fetchCollectionData in CollectionView so the file list re-fetches immediately.


Cause of bug:

CollectionView fetches the collection's file list once on mount and never again. IngestRowContainer had no way to notify its parent when an upload succeeded, so the stale list persisted until the page was reloaded.

Changes

IngestRow.tsx: Added optional onUploadSuccess?: () => void prop to the interface, destructured it in the component, and called it (via ?.()) after a row's submission status is set to "success".

CollectionView.tsx: Passed fetchCollectionData as the onUploadSuccess prop to IngestRowContainer, triggering a re-fetch of the file list on each successful upload.
 
resolves  #24 