### PR TITLE
fix: resolve ingestion progress bar stuck at 0%

### DIFF
--- a/aquillm/ingest/consumers.py
+++ b/aquillm/ingest/consumers.py
@@ -1,4 +1,5 @@
 from typing import Awaitable
+import uuid # Needed to convert the doc_id URL parameter string into a UUID for Document.get_by_id
 from channels.generic.websocket import AsyncWebsocketConsumer
 from channels.auth import AuthMiddlewareStack
 from channels.db import database_sync_to_async, aclose_old_connections
@@ -7,7 +8,7 @@ from django.contrib.auth.models import User
 from django.apps import apps
 from json import dumps
 from aquillm.settings import DEBUG
-from aquillm.models import DESCENDED_FROM_DOCUMENT
+from aquillm.models import DESCENDED_FROM_DOCUMENT, Document # Import Document so we can check ingestion_complete on connect
 from functools import reduce
 import logging
 logger = logging.getLogger(__name__)
@@ -27,6 +28,10 @@ class IngestMonitorConsumer(AsyncWebsocketConsumer):
         else:
             await self.close()
         await self.channel_layer.group_add(f"document-ingest-{self.scope['url_route']['kwargs']['doc_id']}", self.channel_name) # type: ignore
+        doc_id = self.scope['url_route']['kwargs']['doc_id'] # Get the document ID from the URL route
+        doc = await database_sync_to_async(Document.get_by_id)(uuid.UUID(doc_id)) # Look up the document in the DB (must be async-safe)
+        if doc and doc.ingestion_complete: # If ingestion already finished before the client connected, notify immediately
+            await self.send(text_data=dumps({'type': 'document.ingest.complete', 'complete': True})) # Send complete so the frontend bar jumps to 100% instead of staying at 0%
 
     async def document_ingest_complete(self, event):
         await self.send(text_data=dumps(event))


### PR DESCRIPTION
After uploading a document, the ingestion progress bar would stay at 0% even after the document finished processing successfully.

The progress bar now correctly updates to 100% once ingestion completes, without needing a page refresh.

What Was Happening:

The progress bar connects to a WebSocket to receive live updates from the backend. The problem is that it only connects after the upload is submitted, and by that point, the backend has often already finished processing the document and the update messages are gone. The bar never received them, so it stayed at 0%.

This was especially bad for documents that already exist elsewhere in other collections, where processing completes almost instantly.

The Fix

When the progress bar's WebSocket connects, the backend now checks whether the document has already finished processing. If it has, it immediately sends a completion message to the client so the bar jumps to 100% right away.

Files Changed:

aquillm/ingest/consumers.py: 3 lines added to the WebSocket connect handler

resolves #60 