### PR TITLE
fix: chat hangs when LLM hits max_func_calls limit during tool call s…

### DIFF
--- a/aquillm/aquillm/llm.py
+++ b/aquillm/aquillm/llm.py
@@ -384,9 +384,20 @@ class LLMInterface(ABC):
             await send_func(convo)
             if changed == 'unchanged':
                 return
-            last_message = convo[-1]    
+            last_message = convo[-1]
             if isinstance(last_message, AssistantMessage) and last_message.tool_call_id:
                 calls += 1
+        # If we hit the limit, the last message may be an AssistantMessage with an
+        # unexecuted tool call. Execute it, then get one final LLM response with
+        # tools stripped so the LLM is forced to reply with text instead of looping.
+        last = convo[-1]
+        if isinstance(last, AssistantMessage) and last.tool_call_id:
+            convo, _ = await self.complete(convo, max_tokens)
+            await send_func(convo)
+            convo[-1].tools = None
+            convo[-1].tool_choice = None
+            convo, _ = await self.complete(convo, max_tokens)
+            await send_func(convo)
                 
 
 


### PR DESCRIPTION
…equence

When spin() hit the max_func_calls limit, the loop exited with an unexecuted tool call as the last message. The frontend saw an AssistantMessage with tool_call_input and showed a spinner with input disabled forever, since the server had stopped processing.

Now, after the loop exits, any pending tool call is executed and a final LLM response is obtained with tools stripped to force a text reply, leaving the conversation in a usable state.