### PR TITLE
Add message adapter unit tests - p2

### DIFF
--- a/aquillm/aquillm/settings_test.py
+++ b/aquillm/aquillm/settings_test.py
@@ -1,0 +1,27 @@
+from .settings import *
+DEBUG = True
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "WARNING",
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+        "aquillm": {
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+    },
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,11 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = aquillm.settings
+pythonpath = aquillm
 python_files = test_*.py
 addopts = --strict-markers
 testpaths =
     aquillm/tests
     chat/tests
+    tests
+markers =
+    unit: fast unit tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,66 @@
+import uuid
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from aquillm.models import WSConversation
+from aquillm.llm import UserMessage, AssistantMessage, ToolMessage
+
+
+@pytest.fixture
+def user(db):
+    User = get_user_model()
+    return User.objects.create_user(
+        username="adapter_test_user",
+        email="adapter@example.com",
+        password="testpass123",
+    )
+
+
+@pytest.fixture
+def db_conversation(db, user):
+    return WSConversation.objects.create(
+        owner=user,
+        system_prompt="Test system prompt",
+        name="Test Conversation",
+    )
+
+
+@pytest.fixture
+def user_message():
+    return UserMessage(
+        content="Hello from user",
+        rating=5,
+        feedback_text="helpful",
+        message_uuid=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+    )
+
+
+@pytest.fixture
+def assistant_message():
+    return AssistantMessage(
+        content="Hello from assistant",
+        rating=4,
+        feedback_text="good answer",
+        message_uuid=uuid.UUID("22222222-2222-2222-2222-222222222222"),
+        model="gpt-4o",
+        stop_reason="end_turn",
+        tool_call_id="tool-call-1",
+        tool_call_name="search_docs",
+        tool_call_input={"query": "adapter tests"},
+        usage=42,
+    )
+
+
+@pytest.fixture
+def tool_message():
+    return ToolMessage(
+        content="{'result': 'done'}",
+        rating=3,
+        feedback_text="tool output",
+        message_uuid=uuid.UUID("33333333-3333-3333-3333-333333333333"),
+        tool_name="search_docs",
+        arguments={"query": "adapter tests"},
+        for_whom="assistant",
+        result_dict={"result": "done"},
+    )

--- a/tests/unit/test_message_adapters_django_to_pydantic.py
+++ b/tests/unit/test_message_adapters_django_to_pydantic.py
@@ -1,0 +1,129 @@
+import uuid
+import pytest
+from aquillm.llm import UserMessage, AssistantMessage, ToolMessage
+from aquillm.message_adapters import django_message_to_pydantic
+from aquillm.models import Message
+
+pytestmark = pytest.mark.django_db
+
+
+def test_user_row_maps_to_pydantic_message(db_conversation):
+    row = Message(
+        conversation=None,
+        message_uuid=uuid.uuid4(),
+        role="user",
+        content="Hello",
+        rating=5,
+        feedback_text="great",
+        sequence_number=0,
+    )
+
+
+    msg = django_message_to_pydantic(row)
+
+    assert isinstance(msg, UserMessage)
+    assert msg.role == "user"
+    assert msg.content == "Hello"
+    assert msg.rating == 5
+    assert msg.feedback_text == "great"
+    assert msg.message_uuid == row.message_uuid
+
+
+def test_assistant_row_maps_to_pydantic_message(db_conversation):
+    row = Message.objects.create(
+        conversation=db_conversation,
+        message_uuid=uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+        role="assistant",
+        content="Assistant row content",
+        rating=4,
+        feedback_text="solid",
+        sequence_number=1,
+        model="gpt-4o",
+        stop_reason="end_turn",
+        tool_call_id="tc-1",
+        tool_call_name="search_docs",
+        tool_call_input={"query": "adapter"},
+        usage=77,
+    )
+
+    msg = django_message_to_pydantic(row)
+
+    assert isinstance(msg, AssistantMessage)
+    assert msg.role == "assistant"
+    assert msg.content == "Assistant row content"
+    assert msg.rating == 4
+    assert msg.feedback_text == "solid"
+    assert msg.message_uuid == row.message_uuid
+    assert msg.model == "gpt-4o"
+    assert msg.stop_reason == "end_turn"
+    assert msg.tool_call_id == "tc-1"
+    assert msg.tool_call_name == "search_docs"
+    assert msg.tool_call_input == {"query": "adapter"}
+    assert msg.usage == 77
+
+
+def test_tool_row_maps_to_pydantic_message(db_conversation):
+    row = Message.objects.create(
+        conversation=db_conversation,
+        message_uuid=uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+        role="tool",
+        content="Tool row content",
+        rating=2,
+        feedback_text="tool feedback",
+        sequence_number=2,
+        tool_name="search_docs",
+        arguments={"query": "adapter"},
+        for_whom="assistant",
+        result_dict={"result": "done"},
+    )
+
+    msg = django_message_to_pydantic(row)
+
+    assert isinstance(msg, ToolMessage)
+    assert msg.role == "tool"
+    assert msg.content == "Tool row content"
+    assert msg.rating == 2
+    assert msg.feedback_text == "tool feedback"
+    assert msg.message_uuid == row.message_uuid
+    assert msg.tool_name == "search_docs"
+    assert msg.arguments == {"query": "adapter"}
+    assert msg.for_whom == "assistant"
+    assert msg.result_dict == {"result": "done"}
+
+
+def test_assistant_row_defaults_stop_reason_to_end_turn(db_conversation):
+    row = Message.objects.create(
+        conversation=db_conversation,
+        message_uuid=uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd"),
+        role="assistant",
+        content="Assistant with no stop reason",
+        sequence_number=3,
+        stop_reason=None,
+    )
+
+    msg = django_message_to_pydantic(row)
+
+    assert isinstance(msg, AssistantMessage)
+    assert msg.stop_reason == "end_turn"
+
+
+def test_tool_row_applies_safe_defaults_when_fields_missing(db_conversation):
+    row = Message.objects.create(
+        conversation=db_conversation,
+        message_uuid=uuid.UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"),
+        role="tool",
+        content="Tool with missing optional fields",
+        sequence_number=4,
+        tool_name=None,
+        arguments=None,
+        for_whom=None,
+        result_dict=None,
+    )
+
+    msg = django_message_to_pydantic(row)
+
+    assert isinstance(msg, ToolMessage)
+    assert msg.tool_name == ""
+    assert msg.arguments is None
+    assert msg.for_whom == "assistant"
+    assert msg.result_dict == {}

--- a/tests/unit/test_message_adapters_frontend_json.py
+++ b/tests/unit/test_message_adapters_frontend_json.py
@@ -1,0 +1,86 @@
+import pytest
+from aquillm.llm import Conversation
+from aquillm.message_adapters import save_conversation_to_db, build_frontend_conversation_json
+
+pytestmark = pytest.mark.django_db
+
+
+def test_frontend_json_contains_common_fields_for_all_messages(
+    db_conversation,
+    user_message,
+    assistant_message,
+    tool_message,
+):
+    convo = Conversation(
+        system="Frontend system prompt",
+        messages=[user_message, assistant_message, tool_message],
+    )
+    save_conversation_to_db(convo, db_conversation)
+
+    payload = build_frontend_conversation_json(db_conversation)
+
+    assert payload["system"] == "Frontend system prompt"
+    assert len(payload["messages"]) == 3
+
+    for msg in payload["messages"]:
+        assert "role" in msg
+        assert "content" in msg
+        assert "message_uuid" in msg
+        assert "rating" in msg
+        assert isinstance(msg["message_uuid"], str)
+
+
+def test_frontend_json_includes_assistant_fields_when_present(
+    db_conversation,
+    assistant_message,
+):
+    convo = Conversation(system="Assistant JSON test", messages=[assistant_message])
+    save_conversation_to_db(convo, db_conversation)
+
+    payload = build_frontend_conversation_json(db_conversation)
+    msg = payload["messages"][0]
+
+    assert msg["role"] == "assistant"
+    assert msg["tool_call_name"] == "search_docs"
+    assert msg["tool_call_input"] == {"query": "adapter tests"}
+    assert msg["usage"] == 42
+
+
+def test_frontend_json_omits_empty_assistant_optional_fields(db_conversation):
+    from aquillm.models import Message
+    import uuid
+
+    Message.objects.create(
+        conversation=db_conversation,
+        message_uuid=uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff"),
+        role="assistant",
+        content="Assistant without tool call",
+        sequence_number=0,
+        usage=0,
+        tool_call_name=None,
+        tool_call_input=None,
+    )
+
+    payload = build_frontend_conversation_json(db_conversation)
+    msg = payload["messages"][0]
+
+    assert msg["role"] == "assistant"
+    assert "tool_call_name" not in msg
+    assert "tool_call_input" not in msg
+    assert "usage" not in msg
+
+
+def test_frontend_json_includes_tool_fields(
+    db_conversation,
+    tool_message,
+):
+    convo = Conversation(system="Tool JSON test", messages=[tool_message])
+    save_conversation_to_db(convo, db_conversation)
+
+    payload = build_frontend_conversation_json(db_conversation)
+    msg = payload["messages"][0]
+
+    assert msg["role"] == "tool"
+    assert msg["tool_name"] == "search_docs"
+    assert msg["result_dict"] == {"result": "done"}
+    assert msg["for_whom"] == "assistant"

--- a/tests/unit/test_message_adapters_pydantic_to_django.py
+++ b/tests/unit/test_message_adapters_pydantic_to_django.py
@@ -1,0 +1,80 @@
+import pytest
+from aquillm.message_adapters import pydantic_message_to_django
+from aquillm.models import Message
+
+pytestmark = pytest.mark.django_db
+
+
+def test_user_message_maps_to_django_row(user_message, db_conversation):
+    msg = pydantic_message_to_django(user_message, db_conversation, seq_num=0)
+
+    assert isinstance(msg, Message)
+    assert msg.conversation == db_conversation
+    assert msg.message_uuid == user_message.message_uuid
+    assert msg.role == "user"
+    assert msg.content == "Hello from user"
+    assert msg.rating == 5
+    assert msg.feedback_text == "helpful"
+    assert msg.sequence_number == 0
+
+    assert msg.model is None
+    assert msg.stop_reason is None
+    assert msg.tool_call_id is None
+    assert msg.tool_call_name is None
+    assert msg.tool_call_input is None
+    assert msg.usage == 0
+
+    assert msg.tool_name is None
+    assert msg.arguments is None
+    assert msg.for_whom is None
+    assert msg.result_dict is None
+
+
+def test_assistant_message_maps_to_django_row(assistant_message, db_conversation):
+    msg = pydantic_message_to_django(assistant_message, db_conversation, seq_num=1)
+
+    assert isinstance(msg, Message)
+    assert msg.conversation == db_conversation
+    assert msg.message_uuid == assistant_message.message_uuid
+    assert msg.role == "assistant"
+    assert msg.content == "Hello from assistant"
+    assert msg.rating == 4
+    assert msg.feedback_text == "good answer"
+    assert msg.sequence_number == 1
+
+    assert msg.model == "gpt-4o"
+    assert msg.stop_reason == "end_turn"
+    assert msg.tool_call_id == "tool-call-1"
+    assert msg.tool_call_name == "search_docs"
+    assert msg.tool_call_input == {"query": "adapter tests"}
+    assert msg.usage == 42
+
+    assert msg.tool_name is None
+    assert msg.arguments is None
+    assert msg.for_whom is None
+    assert msg.result_dict is None
+
+
+def test_tool_message_maps_to_django_row(tool_message, db_conversation):
+    msg = pydantic_message_to_django(tool_message, db_conversation, seq_num=2)
+
+    assert isinstance(msg, Message)
+    assert msg.conversation == db_conversation
+    assert msg.message_uuid == tool_message.message_uuid
+    assert msg.role == "tool"
+    assert msg.content == "{'result': 'done'}"
+    assert msg.rating == 3
+    assert msg.feedback_text == "tool output"
+    assert msg.sequence_number == 2
+
+    assert msg.tool_name == "search_docs"
+    assert msg.arguments == {"query": "adapter tests"}
+    assert msg.for_whom == "assistant"
+    assert msg.result_dict == {"result": "done"}
+
+    assert msg.model is None
+    assert msg.stop_reason is None
+    assert msg.tool_call_id is None
+    assert msg.tool_call_name is None
+    assert msg.tool_call_input is None
+    assert msg.usage == 0

--- a/tests/unit/test_message_adapters_roundtrip.py
+++ b/tests/unit/test_message_adapters_roundtrip.py
@@ -1,0 +1,54 @@
+import pytest
+from aquillm.llm import UserMessage, AssistantMessage, ToolMessage
+from aquillm.message_adapters import (
+    pydantic_message_to_django,
+    django_message_to_pydantic,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def test_user_message_roundtrip(user_message, db_conversation):
+    row = pydantic_message_to_django(user_message, db_conversation, seq_num=0)
+    restored = django_message_to_pydantic(row)
+
+    assert isinstance(restored, UserMessage)
+    assert restored.role == user_message.role
+    assert restored.content == user_message.content
+    assert restored.rating == user_message.rating
+    assert restored.feedback_text == user_message.feedback_text
+    assert restored.message_uuid == user_message.message_uuid
+
+
+def test_assistant_message_roundtrip(assistant_message, db_conversation):
+    row = pydantic_message_to_django(assistant_message, db_conversation, seq_num=1)
+    restored = django_message_to_pydantic(row)
+
+    assert isinstance(restored, AssistantMessage)
+    assert restored.role == assistant_message.role
+    assert restored.content == assistant_message.content
+    assert restored.rating == assistant_message.rating
+    assert restored.feedback_text == assistant_message.feedback_text
+    assert restored.message_uuid == assistant_message.message_uuid
+    assert restored.model == assistant_message.model
+    assert restored.stop_reason == assistant_message.stop_reason
+    assert restored.tool_call_id == assistant_message.tool_call_id
+    assert restored.tool_call_name == assistant_message.tool_call_name
+    assert restored.tool_call_input == assistant_message.tool_call_input
+    assert restored.usage == assistant_message.usage
+
+
+def test_tool_message_roundtrip(tool_message, db_conversation):
+    row = pydantic_message_to_django(tool_message, db_conversation, seq_num=2)
+    restored = django_message_to_pydantic(row)
+
+    assert isinstance(restored, ToolMessage)
+    assert restored.role == tool_message.role
+    assert restored.content == tool_message.content
+    assert restored.rating == tool_message.rating
+    assert restored.feedback_text == tool_message.feedback_text
+    assert restored.message_uuid == tool_message.message_uuid
+    assert restored.tool_name == tool_message.tool_name
+    assert restored.arguments == tool_message.arguments
+    assert restored.for_whom == tool_message.for_whom
+    assert restored.result_dict == tool_message.result_dict


### PR DESCRIPTION
overall: Add unit tests for the message adapter layer

Files added:
- aquillm/aquillm/settings_test.py
- tests/conftest.py
- tests/unit/test_message_adapters_pydantic_to_django.py
- tests/unit/test_message_adapters_django_to_pydantic.py
- tests/unit/test_message_adapters_roundtrip.py
- tests/unit/test_message_adapters_frontend_json.py

Test command:
docker compose exec web bash -lc "cd /app && DJANGO_SETTINGS_MODULE=aquillm.settings_test python -m pytest -q tests/unit/test_message_adapters_*.py"