### PR TITLE
llm unit tests and commenting

### DIFF
--- a/aquillm/aquillm/llm.py
+++ b/aquillm/aquillm/llm.py
@@ -127,13 +127,12 @@ class ToolChoice(BaseModel):
     name: Optional[str] = None
 
     @model_validator(mode='after')
-    @classmethod
-    def validate_name(cls, data: Any) -> Any:
-        if data.type == 'tool' and data.name is None:
+    def validate_name(self):
+        if self.type == 'tool' and self.name is None:
             raise ValueError("name is required when type is 'tool'")
-        if data.type != 'tool' and data.name is not None:
+        if self.type != 'tool' and self.name is not None:
             raise ValueError("name should only be set when type is 'tool'")
-        return data
+        return self
 
 class __LLMMessage(BaseModel, ABC):
     role: Literal['user', 'tool', 'assistant']
@@ -145,11 +144,11 @@ class __LLMMessage(BaseModel, ABC):
     files: Optional[list[tuple[str, int]]] = None
     message_uuid: uuid.UUID = Field(default_factory=uuid.uuid4)
     
-    @classmethod
     @model_validator(mode='after')
-    def validate_tools(cls, data: Any) -> Any:
-        if (data.tools and not data.tool_choice) or (data.tool_choice and not data.tools):
+    def validate_tools(self):
+        if (self.tools and not self.tool_choice) or (self.tool_choice and not self.tools):
             raise ValueError("Both tools and tool_choice must be populated if tools are used")
+        return self
 
     #render for LLM 
     def render(self, *args, **kwargs) -> dict:
@@ -190,12 +189,12 @@ class AssistantMessage(__LLMMessage):
     tool_call_input: Optional[dict] = None
     usage: int = 0
 
-    @classmethod
     @model_validator(mode='after')
-    def validate_tool_call(cls, data: Any) -> Any:
-        if (any([data.tool_call_id, data.tool_call_name]) and
-        not all([data.tool_call_id, data.tool_call_name])):
+    def validate_tool_call(self):
+        if (any([self.tool_call_id, self.tool_call_name]) and
+        not all([self.tool_call_id, self.tool_call_name])):
             raise ValueError("If a tool call is made, both tool_call_id and tool_call_name must have values")
+        return self
 
 
     # @override
@@ -248,18 +247,17 @@ class Conversation(BaseModel):
     def get_empty_conversation(cls):
         return cls(system=apps.get_app_config('aquillm').system_prompt).model_dump()
 
-    @classmethod
     @model_validator(mode='after')
-    def validate_flip_flop(cls, data: Any) -> Any:
+    def validate_flip_flop(self):
         def isUser(m: LLM_Message):
             return isinstance(m, UserMessage) or (isinstance(m, ToolMessage) and m.for_whom == 'assistant')
 
-        for a, b in zip(data.messages, data.messages[1:]):
+        for a, b in zip(self.messages, self.messages[1:]):
             if isinstance(a, AssistantMessage) and isinstance(b, AssistantMessage):
                 raise ValueError("Conversation has adjacent assistant messages")
             if isUser(a) and isUser(b):
                 raise ValueError("Conversation has adjacent user messages")
-        return data
+        return self
 
 class LLMResponse(BaseModel):
     text: Optional[str]

--- a/aquillm/aquillm/settings_test.py
+++ b/aquillm/aquillm/settings_test.py
@@ -1,5 +1,7 @@
+from os import environ
 from .settings import *
 DEBUG = True
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/tests/unit/test_llm_claude_mapping.py
+++ b/tests/unit/test_llm_claude_mapping.py
@@ -1,0 +1,122 @@
+import asyncio
+from types import SimpleNamespace
+
+from aquillm.llm import ClaudeInterface, Conversation, UserMessage
+
+
+class FakeClaudeMessagesAPI:
+    # this fakes the anthropic messages api
+
+    def __init__(self, response, token_count_value=123):
+        self.response = response
+        self.token_count_value = token_count_value
+        self.last_create_kwargs = None
+        self.last_count_kwargs = None
+
+    async def create(self, **kwargs):
+        # this stores request args so the test can inspect them
+
+        self.last_create_kwargs = kwargs
+        return self.response
+
+    async def count_tokens(self, **kwargs):
+        # this stores token count args so the test can inspect them
+
+        self.last_count_kwargs = kwargs
+        return SimpleNamespace(input_tokens=self.token_count_value)
+
+
+class FakeClaudeClient:
+    # this gives the interface a messages object
+    
+    def __init__(self, response, token_count_value=123):
+        self.messages = FakeClaudeMessagesAPI(response, token_count_value=token_count_value)
+
+
+def test_claude_get_message_maps_text_only_response():
+    # this checks plain text responses map into our standard response object
+
+    response = SimpleNamespace(
+        content=[SimpleNamespace(text="claude says hello")],
+        stop_reason="end_turn",
+        usage=SimpleNamespace(input_tokens=11, output_tokens=7),
+    )
+    client = FakeClaudeClient(response)
+    iface = ClaudeInterface(client, model_override="claude-test-model")
+
+    result = asyncio.run(
+        iface.get_message(
+            system="system text",
+            messages=[{"role": "user", "content": "hi"}],
+            messages_pydantic=[],
+            max_tokens=200,
+        )
+    )
+
+    assert result.text == "claude says hello"
+    assert result.tool_call == {}
+    assert result.stop_reason == "end_turn"
+    assert result.input_usage == 11
+    assert result.output_usage == 7
+    assert result.model == "claude-test-model"
+
+    assert "messages_pydantic" not in client.messages.last_create_kwargs
+    assert client.messages.last_create_kwargs["system"] == "system text"
+    assert client.messages.last_create_kwargs["messages"] == [
+        {"role": "user", "content": "hi"}
+    ]
+
+
+def test_claude_get_message_maps_tool_call_response():
+    # this checks tool calls are extracted from anthropic style content blocks
+
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(text="working on it"),
+            SimpleNamespace(id="tool-123", name="search_docs", input={"query": "adapters"}),
+        ],
+        stop_reason="tool_use",
+        usage=SimpleNamespace(input_tokens=21, output_tokens=9),
+    )
+    client = FakeClaudeClient(response)
+    iface = ClaudeInterface(client, model_override="claude-test-model")
+
+    result = asyncio.run(
+        iface.get_message(
+            system="system text",
+            messages=[{"role": "user", "content": "search for adapters"}],
+            messages_pydantic=[],
+            max_tokens=200,
+        )
+    )
+
+    assert result.text == "working on it"
+    assert result.tool_call["tool_call_id"] == "tool-123"
+    assert result.tool_call["tool_call_name"] == "search_docs"
+    assert result.tool_call["tool_call_input"] == {"query": "adapters"}
+    assert result.stop_reason == "tool_use"
+    assert result.model == "claude-test-model"
+
+
+def test_claude_token_count_uses_rendered_messages_and_new_message():
+    # this checks token counting sends the expected conversation shape
+
+    response = SimpleNamespace(
+        content=[SimpleNamespace(text="ok")],
+        stop_reason="end_turn",
+        usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+    )
+    client = FakeClaudeClient(response, token_count_value=321)
+    iface = ClaudeInterface(client, model_override="claude-test-model")
+
+    convo = Conversation(
+        system="count these tokens",
+        messages=[UserMessage(content="first question")],
+    )
+
+    count = asyncio.run(iface.token_count(convo, new_message="next message"))
+
+    assert count == 321
+    assert client.messages.last_count_kwargs["system"] == "count these tokens"
+    assert client.messages.last_count_kwargs["messages"][0]["content"] == "first question"
+    assert client.messages.last_count_kwargs["messages"][1]["content"] == "next message"

--- a/tests/unit/test_llm_config_apps.py
+++ b/tests/unit/test_llm_config_apps.py
@@ -1,0 +1,127 @@
+import pytest
+from pydantic import ValidationError
+
+from aquillm.llm import (
+    AssistantMessage,
+    ClaudeInterface,
+    Conversation,
+    OpenAIInterface,
+    ToolChoice,
+    UserMessage,
+    message_to_user,
+)
+
+
+def test_message_to_user_tool_definition_is_correct():
+    # this checks the tool metadata that gets exposed to llms
+
+    assert message_to_user.name == "message_to_user"
+    assert message_to_user.for_whom == "user"
+
+    schema = message_to_user.llm_definition["input_schema"]
+
+    assert schema["type"] == "object"
+    assert schema["required"] == ["message"]
+    assert schema["properties"]["message"]["type"] == "string"
+    assert (
+        schema["properties"]["message"]["description"]
+        == "The message to send to the user."
+    )
+
+
+def test_message_to_user_tool_executes():
+    # this checks the wrapped function still runs correctly
+
+    result = message_to_user(message="hello user")
+
+    assert result == {"result": "hello user"}
+
+
+def test_claude_interface_sets_model_override():
+    # this checks we can build a claude interface with a chosen model
+
+    iface = ClaudeInterface(anthropic_client=object(), model_override="claude-test-model")
+
+    assert iface.client is not None
+    assert iface.base_args["model"] == "claude-test-model"
+
+
+def test_gpt_oss_interface_sets_model_name():
+    # this checks gpt oss goes through the openai style interface
+
+    iface = OpenAIInterface(openai_client=object(), model="gpt-oss:20b")
+
+    assert iface.client is not None
+    assert iface.base_args["model"] == "gpt-oss:20b"
+
+
+def test_tool_choice_requires_name_for_tool_type():
+    # this checks a specific tool choice must name the tool
+
+    with pytest.raises(ValueError):
+        ToolChoice(type="tool")
+
+
+def test_tool_choice_rejects_name_for_non_tool_type():
+    # this checks name is only allowed when type is tool
+
+    with pytest.raises(ValueError):
+        ToolChoice(type="auto", name="search_docs")
+
+
+def test_user_message_rejects_tools_without_tool_choice():
+    # this checks tools and tool_choice must be provided together
+
+    with pytest.raises(ValidationError):
+        UserMessage(
+            content="please use tools",
+            tools=[message_to_user],
+        )
+
+
+def test_user_message_rejects_tool_choice_without_tools():
+    # this checks tool_choice alone is not valid
+
+    with pytest.raises(ValidationError):
+        UserMessage(
+            content="please use tools",
+            tool_choice=ToolChoice(type="auto"),
+        )
+
+
+def test_assistant_tool_call_requires_pair():
+    # this checks tool call id and tool call name must come together
+
+    with pytest.raises(ValidationError):
+        AssistantMessage(
+            content="calling a tool",
+            stop_reason="tool_use",
+            tool_call_id="tool-call-1",
+        )
+
+
+def test_conversation_rejects_adjacent_user_messages():
+    # this checks the conversation alternation rule
+
+    with pytest.raises(ValidationError):
+        Conversation(
+            system="test system",
+            messages=[
+                UserMessage(content="first"),
+                UserMessage(content="second"),
+            ],
+        )
+
+
+def test_conversation_rejects_adjacent_assistant_messages():
+    # this checks assistant messages cannot sit next to each other
+
+    with pytest.raises(ValidationError):
+        Conversation(
+            system="test system",
+            messages=[
+                UserMessage(content="hi"),
+                AssistantMessage(content="one", stop_reason="end_turn"),
+                AssistantMessage(content="two", stop_reason="end_turn"),
+            ],
+        )

--- a/tests/unit/test_llm_gpt_oss_mapping.py
+++ b/tests/unit/test_llm_gpt_oss_mapping.py
@@ -1,0 +1,165 @@
+import asyncio
+from types import SimpleNamespace
+
+from aquillm.llm import OpenAIInterface, Conversation, AssistantMessage, UserMessage, gpt_enc
+
+
+class FakeOpenAICompletionsAPI:
+    # this fakes the openai chat completions api
+
+    def __init__(self, response):
+        self.response = response
+        self.last_create_kwargs = None
+
+    async def create(self, **kwargs):
+        # this stores the request args so the test can inspect them
+
+        self.last_create_kwargs = kwargs
+        return self.response
+
+
+class FakeOpenAIChatAPI:
+
+    def __init__(self, response):
+        self.completions = FakeOpenAICompletionsAPI(response)
+
+
+class FakeOpenAIClient:
+    # this gives the interface a reg chat api
+
+    def __init__(self, response):
+        self.chat = FakeOpenAIChatAPI(response)
+
+
+def test_openai_transform_tools_produces_openai_function_schema():
+    # this checks internal tool definitions get converted to openai function tools
+
+    response = SimpleNamespace()
+    client = FakeOpenAIClient(response)
+    iface = OpenAIInterface(client, model="gpt-oss:20b")
+
+    transformed = asyncio.run(
+        iface._transform_tools(
+            [
+                {
+                    "name": "search_docs",
+                    "description": "searches documents",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string", "description": "the search query"}
+                        },
+                    },
+                }
+            ]
+        )
+    )
+
+    assert transformed[0]["type"] == "function"
+    assert transformed[0]["function"]["name"] == "search_docs"
+    assert transformed[0]["function"]["description"] == "searches documents"
+    assert transformed[0]["function"]["parameters"]["type"] == "object"
+    assert transformed[0]["function"]["parameters"]["properties"]["query"]["type"] == "string"
+    assert transformed[0]["function"]["parameters"]["required"] == ["query"]
+    assert transformed[0]["function"]["strict"] is True
+
+
+def test_openai_get_message_maps_text_only_response():
+    # this checks plain text responses map into our standard response object
+
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="gpt oss says hello", tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=14, completion_tokens=6),
+    )
+    client = FakeOpenAIClient(response)
+    iface = OpenAIInterface(client, model="gpt-oss:20b")
+
+    result = asyncio.run(
+        iface.get_message(
+            system="developer instructions",
+            messages=[{"role": "user", "content": "hi"}],
+            messages_pydantic=[],
+            max_tokens=200,
+        )
+    )
+
+    assert result.text == "gpt oss says hello"
+    assert result.tool_call == {}
+    assert result.stop_reason == "stop"
+    assert result.input_usage == 14
+    assert result.output_usage == 6
+    assert result.model == "gpt-oss:20b"
+
+    sent_messages = client.chat.completions.last_create_kwargs["messages"]
+    assert sent_messages[0] == {
+        "role": "developer",
+        "content": "developer instructions",
+    }
+    assert sent_messages[1] == {"role": "user", "content": "hi"}
+
+
+def test_openai_get_message_maps_tool_call_response():
+    # this checks openai style tool calls are converted into our standard fields
+
+    tool_call = SimpleNamespace(
+        id="call-123",
+        function=SimpleNamespace(
+            name="search_docs",
+            arguments='{"query": "adapter tests"}',
+        ),
+    )
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=None, tool_calls=[tool_call]),
+                finish_reason="tool_calls",
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=19, completion_tokens=8),
+    )
+    client = FakeOpenAIClient(response)
+    iface = OpenAIInterface(client, model="gpt-oss:20b")
+
+    result = asyncio.run(
+        iface.get_message(
+            system="developer instructions",
+            messages=[{"role": "user", "content": "search adapter tests"}],
+            messages_pydantic=[],
+            max_tokens=200,
+        )
+    )
+
+    assert result.text is None
+    assert result.tool_call["tool_call_id"] == "call-123"
+    assert result.tool_call["tool_call_name"] == "search_docs"
+    assert result.tool_call["tool_call_input"] == {"query": "adapter tests"}
+    assert result.stop_reason == "tool_calls"
+    assert result.model == "gpt-oss:20b"
+
+
+def test_openai_token_count_uses_latest_assistant_usage_plus_new_message():
+    # this checks that token_count uses the last assistant usage as the running total
+
+    response = SimpleNamespace()
+    client = FakeOpenAIClient(response)
+    iface = OpenAIInterface(client, model="gpt-oss:20b")
+
+    convo = Conversation(
+        system="count tokens",
+        messages=[
+            UserMessage(content="first question"),
+            AssistantMessage(content="first answer", stop_reason="end_turn", usage=40),
+            UserMessage(content="second question"),
+            AssistantMessage(content="second answer", stop_reason="end_turn", usage=75),
+        ],
+    )
+
+    count = asyncio.run(iface.token_count(convo, new_message="next question"))
+    expected = 75 + len(gpt_enc.encode("next question"))
+
+    assert count == expected

--- a/tests/unit/test_message_adapters_django_to_pydantic.py
+++ b/tests/unit/test_message_adapters_django_to_pydantic.py
@@ -4,10 +4,12 @@ from aquillm.llm import UserMessage, AssistantMessage, ToolMessage
 from aquillm.message_adapters import django_message_to_pydantic
 from aquillm.models import Message
 
+# enable database access
 pytestmark = pytest.mark.django_db
 
 
 def test_user_row_maps_to_pydantic_message(db_conversation):
+    # create a user message row
     row = Message(
         conversation=None,
         message_uuid=uuid.uuid4(),
@@ -18,10 +20,13 @@ def test_user_row_maps_to_pydantic_message(db_conversation):
         sequence_number=0,
     )
 
-
+    # convert row to pydantic message
     msg = django_message_to_pydantic(row)
 
+    # verify correct message type
     assert isinstance(msg, UserMessage)
+
+    # verify fields mapped correctly
     assert msg.role == "user"
     assert msg.content == "Hello"
     assert msg.rating == 5
@@ -30,6 +35,7 @@ def test_user_row_maps_to_pydantic_message(db_conversation):
 
 
 def test_assistant_row_maps_to_pydantic_message(db_conversation):
+    # create assistant message row with tool call metadata
     row = Message.objects.create(
         conversation=db_conversation,
         message_uuid=uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
@@ -46,8 +52,10 @@ def test_assistant_row_maps_to_pydantic_message(db_conversation):
         usage=77,
     )
 
+    # convert row to pydantic
     msg = django_message_to_pydantic(row)
 
+    # verify mapping
     assert isinstance(msg, AssistantMessage)
     assert msg.role == "assistant"
     assert msg.content == "Assistant row content"
@@ -63,6 +71,7 @@ def test_assistant_row_maps_to_pydantic_message(db_conversation):
 
 
 def test_tool_row_maps_to_pydantic_message(db_conversation):
+    # create tool message row
     row = Message.objects.create(
         conversation=db_conversation,
         message_uuid=uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc"),
@@ -77,8 +86,10 @@ def test_tool_row_maps_to_pydantic_message(db_conversation):
         result_dict={"result": "done"},
     )
 
+    # convert to pydantic
     msg = django_message_to_pydantic(row)
 
+    # verify mapping
     assert isinstance(msg, ToolMessage)
     assert msg.role == "tool"
     assert msg.content == "Tool row content"
@@ -92,6 +103,7 @@ def test_tool_row_maps_to_pydantic_message(db_conversation):
 
 
 def test_assistant_row_defaults_stop_reason_to_end_turn(db_conversation):
+    # create assistant message without stop reason
     row = Message.objects.create(
         conversation=db_conversation,
         message_uuid=uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd"),
@@ -101,13 +113,16 @@ def test_assistant_row_defaults_stop_reason_to_end_turn(db_conversation):
         stop_reason=None,
     )
 
+    # convert to pydantic
     msg = django_message_to_pydantic(row)
 
+    # verify safe default
     assert isinstance(msg, AssistantMessage)
     assert msg.stop_reason == "end_turn"
 
 
 def test_tool_row_applies_safe_defaults_when_fields_missing(db_conversation):
+    # create tool row with missing optional values
     row = Message.objects.create(
         conversation=db_conversation,
         message_uuid=uuid.UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"),
@@ -120,8 +135,10 @@ def test_tool_row_applies_safe_defaults_when_fields_missing(db_conversation):
         result_dict=None,
     )
 
+    # convert to pydantic
     msg = django_message_to_pydantic(row)
 
+    # verify fallback defaults
     assert isinstance(msg, ToolMessage)
     assert msg.tool_name == ""
     assert msg.arguments is None

--- a/tests/unit/test_message_adapters_frontend_json.py
+++ b/tests/unit/test_message_adapters_frontend_json.py
@@ -2,6 +2,7 @@ import pytest
 from aquillm.llm import Conversation
 from aquillm.message_adapters import save_conversation_to_db, build_frontend_conversation_json
 
+# allow database use
 pytestmark = pytest.mark.django_db
 
 
@@ -11,17 +12,25 @@ def test_frontend_json_contains_common_fields_for_all_messages(
     assistant_message,
     tool_message,
 ):
+    # build conversation with all message types
     convo = Conversation(
         system="Frontend system prompt",
         messages=[user_message, assistant_message, tool_message],
     )
+
+    # persist conversation to database
     save_conversation_to_db(convo, db_conversation)
 
+    # build json payload returned to frontend
     payload = build_frontend_conversation_json(db_conversation)
 
+    # verify system prompt preserved
     assert payload["system"] == "Frontend system prompt"
+
+    # verify all messages returned
     assert len(payload["messages"]) == 3
 
+    # verify common fields included
     for msg in payload["messages"]:
         assert "role" in msg
         assert "content" in msg
@@ -34,12 +43,15 @@ def test_frontend_json_includes_assistant_fields_when_present(
     db_conversation,
     assistant_message,
 ):
+    # create conversation with assistant message
     convo = Conversation(system="Assistant JSON test", messages=[assistant_message])
+
     save_conversation_to_db(convo, db_conversation)
 
     payload = build_frontend_conversation_json(db_conversation)
     msg = payload["messages"][0]
 
+    # verify assistant tool metadata included
     assert msg["role"] == "assistant"
     assert msg["tool_call_name"] == "search_docs"
     assert msg["tool_call_input"] == {"query": "adapter tests"}
@@ -50,6 +62,7 @@ def test_frontend_json_omits_empty_assistant_optional_fields(db_conversation):
     from aquillm.models import Message
     import uuid
 
+    # create assistant message without tool call metadata
     Message.objects.create(
         conversation=db_conversation,
         message_uuid=uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff"),
@@ -64,6 +77,7 @@ def test_frontend_json_omits_empty_assistant_optional_fields(db_conversation):
     payload = build_frontend_conversation_json(db_conversation)
     msg = payload["messages"][0]
 
+    # verify empty optional fields are not included
     assert msg["role"] == "assistant"
     assert "tool_call_name" not in msg
     assert "tool_call_input" not in msg
@@ -74,12 +88,15 @@ def test_frontend_json_includes_tool_fields(
     db_conversation,
     tool_message,
 ):
+    # store conversation with tool message
     convo = Conversation(system="Tool JSON test", messages=[tool_message])
+
     save_conversation_to_db(convo, db_conversation)
 
     payload = build_frontend_conversation_json(db_conversation)
     msg = payload["messages"][0]
 
+    # verify tool metadata included
     assert msg["role"] == "tool"
     assert msg["tool_name"] == "search_docs"
     assert msg["result_dict"] == {"result": "done"}

--- a/tests/unit/test_message_adapters_pydantic_to_django.py
+++ b/tests/unit/test_message_adapters_pydantic_to_django.py
@@ -2,12 +2,15 @@ import pytest
 from aquillm.message_adapters import pydantic_message_to_django
 from aquillm.models import Message
 
+# enable database usage
 pytestmark = pytest.mark.django_db
 
 
 def test_user_message_maps_to_django_row(user_message, db_conversation):
+    # convert pydantic user message into django row
     msg = pydantic_message_to_django(user_message, db_conversation, seq_num=0)
 
+    # verify row type and core fields
     assert isinstance(msg, Message)
     assert msg.conversation == db_conversation
     assert msg.message_uuid == user_message.message_uuid
@@ -17,6 +20,7 @@ def test_user_message_maps_to_django_row(user_message, db_conversation):
     assert msg.feedback_text == "helpful"
     assert msg.sequence_number == 0
 
+    # verify assistant specific fields not populated
     assert msg.model is None
     assert msg.stop_reason is None
     assert msg.tool_call_id is None
@@ -24,6 +28,7 @@ def test_user_message_maps_to_django_row(user_message, db_conversation):
     assert msg.tool_call_input is None
     assert msg.usage == 0
 
+    # verify tool specific fields not populated
     assert msg.tool_name is None
     assert msg.arguments is None
     assert msg.for_whom is None
@@ -31,8 +36,10 @@ def test_user_message_maps_to_django_row(user_message, db_conversation):
 
 
 def test_assistant_message_maps_to_django_row(assistant_message, db_conversation):
+    # convert assistant message to django row
     msg = pydantic_message_to_django(assistant_message, db_conversation, seq_num=1)
 
+    # verify core fields
     assert isinstance(msg, Message)
     assert msg.conversation == db_conversation
     assert msg.message_uuid == assistant_message.message_uuid
@@ -42,6 +49,7 @@ def test_assistant_message_maps_to_django_row(assistant_message, db_conversation
     assert msg.feedback_text == "good answer"
     assert msg.sequence_number == 1
 
+    # verify assistant specific fields
     assert msg.model == "gpt-4o"
     assert msg.stop_reason == "end_turn"
     assert msg.tool_call_id == "tool-call-1"
@@ -49,6 +57,7 @@ def test_assistant_message_maps_to_django_row(assistant_message, db_conversation
     assert msg.tool_call_input == {"query": "adapter tests"}
     assert msg.usage == 42
 
+    # verify tool fields not populated
     assert msg.tool_name is None
     assert msg.arguments is None
     assert msg.for_whom is None
@@ -56,8 +65,10 @@ def test_assistant_message_maps_to_django_row(assistant_message, db_conversation
 
 
 def test_tool_message_maps_to_django_row(tool_message, db_conversation):
+    # convert tool message to django row
     msg = pydantic_message_to_django(tool_message, db_conversation, seq_num=2)
 
+    # verify core fields
     assert isinstance(msg, Message)
     assert msg.conversation == db_conversation
     assert msg.message_uuid == tool_message.message_uuid
@@ -67,11 +78,13 @@ def test_tool_message_maps_to_django_row(tool_message, db_conversation):
     assert msg.feedback_text == "tool output"
     assert msg.sequence_number == 2
 
+    # verify tool specific fields
     assert msg.tool_name == "search_docs"
     assert msg.arguments == {"query": "adapter tests"}
     assert msg.for_whom == "assistant"
     assert msg.result_dict == {"result": "done"}
 
+    # verify assistant specific fields empty
     assert msg.model is None
     assert msg.stop_reason is None
     assert msg.tool_call_id is None

--- a/tests/unit/test_message_adapters_roundtrip.py
+++ b/tests/unit/test_message_adapters_roundtrip.py
@@ -5,14 +5,21 @@ from aquillm.message_adapters import (
     django_message_to_pydantic,
 )
 
+# enable database access for these tests
 pytestmark = pytest.mark.django_db
 
 
 def test_user_message_roundtrip(user_message, db_conversation):
+    # change a pydantic user message to a django row
     row = pydantic_message_to_django(user_message, db_conversation, seq_num=0)
+
+    # change the row back to a pydantic message
     restored = django_message_to_pydantic(row)
 
+    # verify message type survived the roundtrip
     assert isinstance(restored, UserMessage)
+
+    # verify common fields are preserved
     assert restored.role == user_message.role
     assert restored.content == user_message.content
     assert restored.rating == user_message.rating
@@ -21,15 +28,23 @@ def test_user_message_roundtrip(user_message, db_conversation):
 
 
 def test_assistant_message_roundtrip(assistant_message, db_conversation):
+    # change assistant message to django model
     row = pydantic_message_to_django(assistant_message, db_conversation, seq_num=1)
+
+    # change back to pydantic message
     restored = django_message_to_pydantic(row)
 
+    # verify correct message type
     assert isinstance(restored, AssistantMessage)
+
+    # verify common fields
     assert restored.role == assistant_message.role
     assert restored.content == assistant_message.content
     assert restored.rating == assistant_message.rating
     assert restored.feedback_text == assistant_message.feedback_text
     assert restored.message_uuid == assistant_message.message_uuid
+
+    # verify assistant specific fields
     assert restored.model == assistant_message.model
     assert restored.stop_reason == assistant_message.stop_reason
     assert restored.tool_call_id == assistant_message.tool_call_id
@@ -39,15 +54,23 @@ def test_assistant_message_roundtrip(assistant_message, db_conversation):
 
 
 def test_tool_message_roundtrip(tool_message, db_conversation):
+    # change tool message to django model
     row = pydantic_message_to_django(tool_message, db_conversation, seq_num=2)
+
+    # change back to pydantic message
     restored = django_message_to_pydantic(row)
 
+    # verify type
     assert isinstance(restored, ToolMessage)
+
+    # verify common fields
     assert restored.role == tool_message.role
     assert restored.content == tool_message.content
     assert restored.rating == tool_message.rating
     assert restored.feedback_text == tool_message.feedback_text
     assert restored.message_uuid == tool_message.message_uuid
+
+    # verify tool specific fields
     assert restored.tool_name == tool_message.tool_name
     assert restored.arguments == tool_message.arguments
     assert restored.for_whom == tool_message.for_whom


### PR DESCRIPTION
This is the complete llm configuration unit tests, in conjunction with better commenting on the message adapter tests.

the command to run exclusively the llm config tests is as follows: 
docker compose exec web bash -lc "cd /app && PYTHONPATH=/app/aquillm DJANGO_SETTINGS_MODULE=aquillm.settings_test python -m pytest -q \
tests/unit/test_llm_config_apps.py \
tests/unit/test_llm_claude_mapping.py \
tests/unit/test_llm_gpt_oss_mapping.py"

and the command to run both the message adapter tests and the llm config tests is as follows: 
docker compose exec web bash -lc "cd /app && PYTHONPATH=/app/aquillm DJANGO_SETTINGS_MODULE=aquillm.settings_test python -m pytest -q tests/unit"