### PR TITLE
Timestamps in chat messages are now accurate

### DIFF
--- a/aquillm/aquillm/message_adapters.py
+++ b/aquillm/aquillm/message_adapters.py
@@ -8,6 +8,8 @@ This file keeps all the conversion logic in one place so consumers.py doesn't ne
 about database column mapping — it just calls save/load/build.
 """
 
+from django.utils import timezone
+
 from .models import Message, WSConversation
 from .llm import (
     Conversation, UserMessage, AssistantMessage, ToolMessage,
@@ -72,6 +74,7 @@ def django_message_to_pydantic(msg: Message) -> LLM_Message:
         'rating': msg.rating,
         'feedback_text': msg.feedback_text,
         'message_uuid': msg.message_uuid,
+        'created_at': msg.created_at,
     }
 
     if msg.role == 'assistant':
@@ -202,6 +205,7 @@ def build_frontend_conversation_json(db_convo: WSConversation) -> dict:
             'content': msg.content,
             'message_uuid': str(msg.message_uuid),  # convert UUID to string for JSON
             'rating': msg.rating,
+            'created_at': msg.created_at.isoformat() if msg.created_at else None,
         }
 
         # Add role-specific fields only when they have data
@@ -231,6 +235,7 @@ def pydantic_message_to_frontend_dict(msg: LLM_Message) -> dict:
         'content': content,
         'message_uuid': str(msg.message_uuid),
         'rating': msg.rating,
+        'created_at': (msg.created_at or timezone.now()).isoformat(),
     }
 
     if isinstance(msg, AssistantMessage):

--- a/aquillm/lib/llm/types/messages.py
+++ b/aquillm/lib/llm/types/messages.py
@@ -1,6 +1,7 @@
 """LLM message types for conversation handling."""
 from typing import Literal, Optional, Any
 from os import getenv
+from datetime import datetime
 import re
 from pydantic import BaseModel, Field, model_validator
 from abc import ABC
@@ -20,6 +21,7 @@ class __LLMMessage(BaseModel, ABC):
     feedback_text: Optional[str] = None
     files: Optional[list[tuple[str, int]]] = None
     message_uuid: uuid.UUID = Field(default_factory=uuid.uuid4)
+    created_at: Optional[datetime] = None
     
     @classmethod
     @model_validator(mode='after')

--- a/react/src/features/chat/components/MessageBubble.tsx
+++ b/react/src/features/chat/components/MessageBubble.tsx
@@ -14,7 +14,42 @@ interface MessageBubbleProps {
 }
 
 export const MessageBubble: React.FC<MessageBubbleProps> = ({ message, onRate, onFeedback }) => {
-  const displayTime = new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  const formatTimestamp = (isoString?: string): { display: string; tooltip: string } | null => {
+    if (!isoString) return null;
+    const date = new Date(isoString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffSeconds = Math.floor(diffMs / 1000);
+    const diffMinutes = Math.floor(diffSeconds / 60);
+    const diffHours = Math.floor(diffMinutes / 60);
+    const diffDays = Math.floor(diffHours / 24);
+
+    const tooltip = date.toLocaleString([], {
+      weekday: 'short', year: 'numeric', month: 'short', day: 'numeric',
+      hour: 'numeric', minute: '2-digit', timeZoneName: 'short'
+    });
+
+    let display: string;
+    if (diffHours < 48) {
+      const time = date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+      display = date.getDate() !== now.getDate() ? `yesterday at ${time}` : `today at ${time}`;
+    } else if (diffDays < 14) {
+      display = `${diffDays} days ago`;
+    } else if (diffDays < 60) {
+      const weeks = Math.floor(diffDays / 7);
+      display = weeks === 1 ? '1 week ago' : `${weeks} weeks ago`;
+    } else if (diffDays < 365) {
+      const months = Math.floor(diffDays / 30);
+      display = months === 1 ? '1 month ago' : `${months} months ago`;
+    } else {
+      const years = Math.floor(diffDays / 365);
+      display = years === 1 ? '1 year ago' : `${years} years ago`;
+    }
+
+    return { display, tooltip };
+  };
+
+  const timestamp = formatTimestamp(message.created_at);
 
   const getMessageClasses = () => {
     let classes = "w-full p-2 rounded-[10px] shadow-sm whitespace-pre-wrap break-words element-border leading-[1.35] text-[14px]";
@@ -163,9 +198,11 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({ message, onRate, o
             </ul>
           </div>
         )}
-        <p className="text-[11px] mt-1 text-text-low_contrast">
-          {displayTime}
-        </p>
+        {timestamp && (
+          <p className="text-[11px] mt-1 text-text-low_contrast" title={timestamp.tooltip}>
+            {timestamp.display}
+          </p>
+        )}
         </div>
       </div>
     </div>

--- a/react/src/features/chat/types/index.ts
+++ b/react/src/features/chat/types/index.ts
@@ -11,6 +11,7 @@ export interface Message {
   for_whom?: 'user' | 'assistant';
   usage?: number;
   files?: [string, number][];
+  created_at?: string;
 }
 
 export interface Collection {


### PR DESCRIPTION
Display as "x {days|weeks|months|years} ago" or "{today|yesterday} at 6:30pm" as appropriate, full datetime and time zone in tooltip.