### PR TITLE
p1: Adding feedback filter schema metadata endpoint

### DIFF
--- a/aquillm/apps/platform_admin/services/filter_schema.py
+++ b/aquillm/apps/platform_admin/services/filter_schema.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from django.db import models
+
+from apps.chat.models import Message
+
+
+TEXT_OPERATORS = [
+    "equals",
+    "not_equals",
+    "contains",
+    "starts_with",
+    "ends_with",
+    "is_empty",
+    "is_not_empty",
+]
+
+NUMBER_OPERATORS = [
+    "equals",
+    "not_equals",
+    "greater_than",
+    "greater_than_or_equal",
+    "less_than",
+    "less_than_or_equal",
+    "is_empty",
+    "is_not_empty",
+]
+
+DATETIME_OPERATORS = [
+    "equals",
+    "not_equals",
+    "after",
+    "on_or_after",
+    "before",
+    "on_or_before",
+    "is_empty",
+    "is_not_empty",
+]
+
+BOOLEAN_OPERATORS = [
+    "equals",
+    "not_equals",
+]
+
+UUID_OPERATORS = [
+    "equals",
+    "not_equals",
+    "is_empty",
+    "is_not_empty",
+]
+
+
+EXCLUDED_MESSAGE_FIELDS = {
+    "content",
+    "tool_call_input",
+    "arguments",
+    "result_dict",
+}
+
+
+def _field_type(field: models.Field) -> str | None:
+    """Map Django model fields to dashboard filter field types."""
+    if isinstance(field, models.UUIDField):
+        return "uuid"
+
+    if isinstance(field, (models.DateTimeField, models.DateField)):
+        return "datetime"
+
+    if isinstance(field, (models.IntegerField, models.FloatField, models.DecimalField)):
+        return "number"
+
+    if isinstance(field, models.BooleanField):
+        return "boolean"
+
+    if isinstance(field, (models.CharField, models.TextField)):
+        return "text"
+
+    if isinstance(field, models.ForeignKey):
+        return "number"
+
+    return None
+
+
+def _operators_for_type(field_type: str) -> list[str]:
+    """Return supported operators for a normalized field type."""
+    if field_type == "text":
+        return TEXT_OPERATORS
+
+    if field_type == "number":
+        return NUMBER_OPERATORS
+
+    if field_type == "datetime":
+        return DATETIME_OPERATORS
+
+    if field_type == "boolean":
+        return BOOLEAN_OPERATORS
+
+    if field_type == "uuid":
+        return UUID_OPERATORS
+
+    return []
+
+
+def feedback_filter_fields() -> list[dict[str, object]]:
+    """Return filterable Message fields for feedback dashboard filtering.
+
+    This only exposes metadata. Query execution, PRQL generation, and frontend
+    rendering should stay in separate PRs.
+    """
+    fields: list[dict[str, object]] = []
+
+    for field in Message._meta.fields:
+        if field.name in EXCLUDED_MESSAGE_FIELDS:
+            continue
+
+        field_type = _field_type(field)
+        if field_type is None:
+            continue
+
+        fields.append(
+            {
+                "name": field.name,
+                "label": field.verbose_name.title(),
+                "type": field_type,
+                "operators": _operators_for_type(field_type),
+            }
+        )
+
+    return fields

--- a/aquillm/apps/platform_admin/urls.py
+++ b/aquillm/apps/platform_admin/urls.py
@@ -11,6 +11,7 @@ api_urlpatterns = [
     path("users/search/", api_views.search_users, name="api_search_users"),
     path("whitelisted_email/<str:email>/", api_views.whitelisted_email, name="api_whitelist_email"),
     path("whitelisted_emails/", api_views.whitelisted_emails, name="api_whitelist_emails"),
+    path("feedback/filter-schema/", api_views.feedback_filter_schema, name="api_feedback_filter_schema"),
     path("feedback/ratings.csv", api_views.feedback_ratings_csv, name="api_feedback_ratings_csv"),
 ]
 

--- a/aquillm/apps/platform_admin/views/api.py
+++ b/aquillm/apps/platform_admin/views/api.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from django.views.decorators.http import require_http_methods
 
 from apps.platform_admin.models import EmailWhitelist
+from apps.platform_admin.services.filter_schema import feedback_filter_fields
 from apps.platform_admin.services.feedback_export import (
     parse_query_bounds,
     stream_feedback_csv_gzip_bytes,
@@ -106,6 +107,16 @@ def whitelisted_email(request, email):
 
 @login_required
 @require_http_methods(["GET"])
+def feedback_filter_schema(request):
+    """Return filterable feedback fields and supported operators."""
+    if not request.user.is_superuser:
+        return HttpResponseForbidden("Superuser access required")
+
+    return JsonResponse({"fields": feedback_filter_fields()})
+
+
+@login_required
+@require_http_methods(["GET"])
 def feedback_ratings_csv(request):
     """Stream CSV of message ratings/feedback (superuser only)."""
     if not request.user.is_superuser:
@@ -161,6 +172,7 @@ def feedback_ratings_csv(request):
 
 
 __all__ = [
+    'feedback_filter_schema',
     'feedback_ratings_csv',
     'search_users',
     'whitelisted_emails',


### PR DESCRIPTION
this is the first part of multiple different pull requests to reinstate my previous code without pushing it all on the same branch, because doing that runs into the size filters once enough code goes through.

Scope: 
This first PR adds a backend service that exposes filterable feedback fields from the Message model schema. It also maps Django field types to supported filter operators and adds a superuser exclusive API endpoint for the filter schema.