### PR TITLE
p5: Adds PRQL validation helper

### DIFF
--- a/aquillm/apps/platform_admin/services/prql_validation.py
+++ b/aquillm/apps/platform_admin/services/prql_validation.py
@@ -1,0 +1,32 @@
+
+
+
+from __future__ import annotations
+
+
+class PRQLValidationError(ValueError):
+    """Raised when PRQL cannot be compiled."""
+
+
+def validate_prql(prql_query: str, *, dialect: str = "postgres") -> str:
+    """Compile PRQL and return generated SQL for validation/debugging only.
+
+    The returned SQL is not executed here. Callers should use this only to
+    verify that generated PRQL is accepted by prqlc.
+    """
+    try:
+        import prql_python as prql
+    except ImportError as exc:
+        raise PRQLValidationError(
+            "prql-python is not installed. Add prql-python to project dependencies."
+        ) from exc
+
+    try:
+        options = prql.CompileOptions(
+            target=f"sql.{dialect}",
+            signature_comment=False,
+            format=False,
+        )
+        return prql.compile(prql_query, options)
+    except Exception as exc:
+        raise PRQLValidationError(f"PRQL validation failed: {exc}") from exc


### PR DESCRIPTION
This Pull Request adds a small PRQL validation helper that uses prql-python/prqlc's compilation to verify the  PRQL syntax. This PR pretty directly addresses the PRQL/prqlc requirement while keeping query execution out of the current scope so I can make sure to make that a separate PR down the line.