### PR TITLE
p8: Add feedback dashboard summary API

### DIFF
--- a/aquillm/apps/platform_admin/urls.py
+++ b/aquillm/apps/platform_admin/urls.py
@@ -12,6 +12,7 @@ api_urlpatterns = [
     path("whitelisted_email/<str:email>/", api_views.whitelisted_email, name="api_whitelist_email"),
     path("whitelisted_emails/", api_views.whitelisted_emails, name="api_whitelist_emails"),
     path("feedback/ratings.csv", api_views.feedback_ratings_csv, name="api_feedback_ratings_csv"),
+    path("feedback/dashboard/summary/", api_views.feedback_dashboard_summary, name="api_feedback_dashboard_summary"),
 ]
 
 # Page URL patterns (to be included under /aquillm/)

--- a/aquillm/apps/platform_admin/views/api.py
+++ b/aquillm/apps/platform_admin/views/api.py
@@ -16,6 +16,8 @@ from apps.platform_admin.services.feedback_export import (
     stream_feedback_csv_gzip_bytes,
     stream_feedback_csv_lines,
 )
+from apps.platform_admin.services.feedback_dataset import FeedbackFilters
+from apps.platform_admin.services.feedback_aggregates import get_summary_metrics
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -160,7 +162,26 @@ def feedback_ratings_csv(request):
     return response
 
 
+@login_required
+@require_http_methods(["GET"])
+def feedback_dashboard_summary(request):
+    """Return aggregate summary metrics for the feedback dashboard."""
+    if not request.user.is_superuser:
+        return HttpResponseForbidden("Superuser access required")
+
+    filters = FeedbackFilters.from_request_params(request.GET.dict())
+    summary = get_summary_metrics(filters)
+
+    summary["rating_distribution"] = {
+        str(rating): count
+        for rating, count in summary["rating_distribution"].items()
+    }
+
+    return JsonResponse(summary)
+
+
 __all__ = [
+    'feedback_dashboard_summary',
     'feedback_ratings_csv',
     'search_users',
     'whitelisted_emails',


### PR DESCRIPTION
### Depends on: PR #138 
### Do not merge before PR #138, once PR 138 is merged I will adjust the base of this Pull Request to development. (the reason that isn't the case right now is so this PR only shows the work done for this PR, not also the work it relies on)

This is a stacked PR on top of the feedback aggregate metrics PR (PR #138). It adds the feedback summary API endpoint, returns the aggregate dashboard metrics from get_summary_metrics, and converts rating distribution keys to strings for better JSON compatibility.