### PR TITLE
p9: Add feedback dashboard filter options API

### DIFF
--- a/aquillm/apps/platform_admin/urls.py
+++ b/aquillm/apps/platform_admin/urls.py
@@ -12,6 +12,7 @@ api_urlpatterns = [
     path("whitelisted_email/<str:email>/", api_views.whitelisted_email, name="api_whitelist_email"),
     path("whitelisted_emails/", api_views.whitelisted_emails, name="api_whitelist_emails"),
     path("feedback/ratings.csv", api_views.feedback_ratings_csv, name="api_feedback_ratings_csv"),
+    path("feedback/dashboard/filters/", api_views.feedback_dashboard_filters, name="api_feedback_dashboard_filters"),
 ]
 
 # Page URL patterns (to be included under /aquillm/)

--- a/aquillm/apps/platform_admin/views/api.py
+++ b/aquillm/apps/platform_admin/views/api.py
@@ -16,6 +16,7 @@ from apps.platform_admin.services.feedback_export import (
     stream_feedback_csv_gzip_bytes,
     stream_feedback_csv_lines,
 )
+from apps.platform_admin.services.feedback_aggregates import get_filter_options
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -160,7 +161,18 @@ def feedback_ratings_csv(request):
     return response
 
 
+@login_required
+@require_http_methods(["GET"])
+def feedback_dashboard_filters(request):
+    """Return available filter option values for the feedback dashboard."""
+    if not request.user.is_superuser:
+        return HttpResponseForbidden("Superuser access required")
+
+    return JsonResponse(get_filter_options())
+
+
 __all__ = [
+    'feedback_dashboard_filters',
     'feedback_ratings_csv',
     'search_users',
     'whitelisted_emails',


### PR DESCRIPTION
### Depends on: PR https://github.com/AquiLLM/AquiLLM/pull/138
### Do not merge before PR https://github.com/AquiLLM/AquiLLM/pull/138, once PR 138 is merged I will adjust the base of this Pull Request to development. (the reason that isn't the case right now is so this PR only shows the work done for this PR, not also the work it relies on)

This is a stacked PR on top of the feedback aggregate metrics PR (PR https://github.com/AquiLLM/AquiLLM/pull/138), and this PR adds the dashboard filter options API endpoint as well as returning available users, roles, models, tool names, and ratings through get_filter_options.