### PR TITLE
p10: Add feedback dashboard page route

### DIFF
--- a/aquillm/apps/platform_admin/urls.py
+++ b/aquillm/apps/platform_admin/urls.py
@@ -18,4 +18,5 @@ api_urlpatterns = [
 page_urlpatterns = [
     path("gemini-costs/", page_views.gemini_cost_monitor, name="gemini_cost_monitor"),
     path("email_whitelist/", page_views.email_whitelist, name="email_whitelist"),
+    path("feedback-dashboard/", page_views.feedback_dashboard, name="feedback_dashboard"),
 ]

--- a/aquillm/apps/platform_admin/views/pages.py
+++ b/aquillm/apps/platform_admin/views/pages.py
@@ -2,6 +2,7 @@
 import structlog
 
 from django.contrib.auth.decorators import login_required, user_passes_test
+from django.http import HttpResponseForbidden
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
 
@@ -26,7 +27,18 @@ def email_whitelist(request):
     return render(request, 'aquillm/email_whitelist.html')
 
 
+@login_required
+@require_http_methods(['GET'])
+def feedback_dashboard(request):
+    """Display the superuser-only feedback dashboard page."""
+    if not request.user.is_superuser:
+        return HttpResponseForbidden("Superuser access required")
+
+    return render(request, 'aquillm/feedback_dashboard.html')
+
+
 __all__ = [
+    'feedback_dashboard',
     'gemini_cost_monitor',
     'email_whitelist',
 ]

--- a/aquillm/templates/aquillm/feedback_dashboard.html
+++ b/aquillm/templates/aquillm/feedback_dashboard.html
@@ -1,0 +1,13 @@
+{% extends "aquillm/base.html" %}
+{% block title %}AquiLLM — Feedback Dashboard{% endblock %}
+
+{% block content %}
+<div class="h-full w-full p-6">
+  <div class="max-w-5xl">
+    <h1 class="text-2xl font-semibold text-text-normal mb-3">Feedback Dashboard</h1>
+    <p class="text-text-muted">
+      Feedback dashboard page route is available. The interactive dashboard UI will be added in a follow-up PR.
+    </p>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This PR adds the /aquillm/feedback-dashboard/ platform admin page route and a temporary placeholder template for the feedback dashboard page. This PR is purposefully leaving the React mounting for a later PR to ensure proper and safe procedure.