### PR TITLE
p12: Add feedback dashboard URL context entry

### DIFF
--- a/aquillm/aquillm/context_processors.py
+++ b/aquillm/aquillm/context_processors.py
@@ -84,6 +84,7 @@ _PAGE_URL_SPECS: list[tuple[str, str, dict[str, Any] | None]] = [
     ("pdf_ingestion_monitor", "pdf_ingestion_monitor", {"doc_id": 0}),
     ("ingestion_dashboard", "ingestion_dashboard", None),
     ("email_whitelist", "email_whitelist", None),
+    ("feedback_dashboard", "feedback_dashboard", None),
     ("ingest_handwritten_notes", "ingest_handwritten_notes", None),
     ("gemini_cost_monitor", "gemini_cost_monitor", None),
     ("new_ws_convo", "new_ws_convo", None),


### PR DESCRIPTION
### Depends on: PR https://github.com/AquiLLM/AquiLLM/pull/144
### Do not merge before PR https://github.com/AquiLLM/AquiLLM/pull/144, once PR https://github.com/AquiLLM/AquiLLM/pull/144 is merged I will adjust the base of this Pull Request to development. (the reason that isn't the case now is so this PR only shows the work done for this PR, not also the work it relies on)

This PR adds the feedback dashboard page URL into the shared template URL context.