### PR TITLE
p13: Add legacy feedback dashboard route

### DIFF
--- a/aquillm/aquillm/views.py
+++ b/aquillm/aquillm/views.py
@@ -59,6 +59,7 @@ from apps.ingestion.views.pages import (
 from apps.platform_admin.views.pages import (
     gemini_cost_monitor,
     email_whitelist,
+    feedback_dashboard,
 )
 
 # Re-export bug report views
@@ -84,6 +85,7 @@ urlpatterns = [
     path("pdf_ingestion_monitor/<int:doc_id>/", pdf_ingestion_monitor, name="pdf_ingestion_monitor"),
     path("ingestion_dashboard/", ingestion_dashboard, name="ingestion_dashboard"),
     path("email_whitelist/", email_whitelist, name="email_whitelist"),
+    path("feedback-dashboard/", feedback_dashboard, name="feedback_dashboard"),
     path("ingest_handwritten_notes/", ingest_handwritten_notes, name="ingest_handwritten_notes"),
     path('gemini-costs/', gemini_cost_monitor, name='gemini_cost_monitor'),
     path('bug-reports/', bug_reports_admin, name='bug_reports_admin'),


### PR DESCRIPTION
### Depends on: PR https://github.com/AquiLLM/AquiLLM/pull/144
### Do not merge before PR https://github.com/AquiLLM/AquiLLM/pull/144, once PR https://github.com/AquiLLM/AquiLLM/pull/144 is merged I will adjust the base of this Pull Request to development. (the reason that isn't the case now is so this PR only shows the work done for this PR, not also the work it relies on)

This PR adds the feedback dashboard route to aquillm/aquillm/views.py and imports feedback_dashboard from platform_admin page views.