### PR TITLE
p16: Add feedback dashboard filters API URL context

### DIFF
--- a/aquillm/aquillm/context_processors.py
+++ b/aquillm/aquillm/context_processors.py
@@ -53,6 +53,7 @@ _API_URL_SPECS: list[tuple[str, str, dict[str, Any] | None]] = [
     ("api_whitelist_email", "api_whitelist_email", {"email": "placeholder@example.com"}),
     ("api_whitelist_emails", "api_whitelist_emails", None),
     ("api_feedback_ratings_csv", "api_feedback_ratings_csv", None),
+    ("api_feedback_dashboard_filters", "api_feedback_dashboard_filters", None),
     ("api_ingest_vtt", "api_ingest_vtt", None),
     ("api_ingest_uploads", "api_ingest_uploads", None),
     ("api_ingest_uploads_status", "api_ingest_uploads_status", {"batch_id": 0}),


### PR DESCRIPTION
### Depends on: PR #143 
### Do not merge before PR #143, once PR #143 is merged I will adjust the base of this Pull Request to development. (the reason that isn't the case now is so this PR only shows the work done for this PR, not also the work it relies on)

This PR adds the feedback dashboard filter options API route to the shared API URL context map.
