### PR TITLE
p19: Add feedback dashboard PRQL display API

### DIFF
--- a/aquillm/apps/platform_admin/urls.py
+++ b/aquillm/apps/platform_admin/urls.py
@@ -12,6 +12,7 @@ api_urlpatterns = [
     path("whitelisted_email/<str:email>/", api_views.whitelisted_email, name="api_whitelist_email"),
     path("whitelisted_emails/", api_views.whitelisted_emails, name="api_whitelist_emails"),
     path("feedback/ratings.csv", api_views.feedback_ratings_csv, name="api_feedback_ratings_csv"),
+    path("feedback/dashboard/prql/", api_views.feedback_dashboard_prql, name="api_feedback_dashboard_prql"),
 ]
 
 # Page URL patterns (to be included under /aquillm/)

--- a/aquillm/apps/platform_admin/views/api.py
+++ b/aquillm/apps/platform_admin/views/api.py
@@ -1,4 +1,5 @@
 """API views for platform administration."""
+import json
 import structlog
 
 from django.contrib.auth import get_user_model
@@ -11,6 +12,7 @@ from django.utils import timezone
 from django.views.decorators.http import require_http_methods
 
 from apps.platform_admin.models import EmailWhitelist
+from apps.platform_admin.services.feedback_prql import build_feedback_prql
 from apps.platform_admin.services.feedback_export import (
     parse_query_bounds,
     stream_feedback_csv_gzip_bytes,
@@ -160,7 +162,28 @@ def feedback_ratings_csv(request):
     return response
 
 
+@login_required
+@require_http_methods(["GET"])
+def feedback_dashboard_prql(request):
+    """Return display-only PRQL for the feedback dashboard filters."""
+    if not request.user.is_superuser:
+        return HttpResponseForbidden("Superuser access required")
+
+    raw_filters = request.GET.get("filters", "[]")
+    try:
+        filters = json.loads(raw_filters)
+    except json.JSONDecodeError:
+        return HttpResponseBadRequest("Invalid filters JSON")
+
+    if not isinstance(filters, list):
+        return HttpResponseBadRequest("filters must be a JSON list")
+
+    prql = build_feedback_prql(filters)
+    return JsonResponse({"prql": prql})
+
+
 __all__ = [
+    'feedback_dashboard_prql',
     'feedback_ratings_csv',
     'search_users',
     'whitelisted_emails',


### PR DESCRIPTION
### Depends on: PR https://github.com/AquiLLM/AquiLLM/pull/137
### Do not merge before PR https://github.com/AquiLLM/AquiLLM/pull/137, once PR https://github.com/AquiLLM/AquiLLM/pull/137 is merged I will adjust the base of this Pull Request to development. (the reason that isn't the case now is so this PR only shows the work done for this PR, not also the work it relies on)

This PR adds a superuser only API endpoint that returns appropriate display only PRQL for the feedback dashboard. This PR is specifically for display, it doesn't compile or execute PRQL on its own.
