### PR TITLE
p25: Add feedback dashboard export button

### DIFF
--- a/react/src/components/FeedbackDashboard/ExportButton.tsx
+++ b/react/src/components/FeedbackDashboard/ExportButton.tsx
@@ -1,0 +1,61 @@
+// ExportButton.tsx
+// builds the export url from current filter query string and triggers a
+// browser file download — does not load data into memory, the browser
+// handles the streaming response directly
+
+import React, { useState } from 'react';
+
+interface ExportButtonProps {
+  apiExport: string;
+  exportQueryString: string;
+  totalCount: number;
+}
+
+const ExportButton: React.FC<ExportButtonProps> = ({
+  apiExport,
+  exportQueryString,
+  totalCount,
+}) => {
+  const [clicked, setClicked] = useState(false);
+
+  const handleExport = () => {
+    // build the full url with current filter params
+    const url = exportQueryString
+      ? `${apiExport}?${exportQueryString}`
+      : apiExport;
+
+    // create a hidden anchor and click it — this lets the browser handle the
+    // streaming response including content-disposition attachment header
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = ''; // filename comes from content-disposition
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+
+    // brief visual feedback
+    setClicked(true);
+    setTimeout(() => setClicked(false), 1500);
+  };
+
+  const label = totalCount > 0
+    ? `Export CSV (${totalCount.toLocaleString()} rows)`
+    : 'Export CSV';
+
+  return (
+    <button
+      onClick={handleExport}
+      disabled={totalCount === 0}
+      className={`px-4 py-[7px] rounded-[8px] text-sm border transition-colors font-medium
+        ${clicked
+          ? 'bg-green text-slight_muted_white border-green'
+          : 'bg-scheme-shade_4 border-border-mid_contrast text-text-normal hover:bg-scheme-shade_5'
+        }
+        disabled:opacity-40 disabled:cursor-not-allowed`}
+    >
+      {clicked ? '✓ Downloading…' : label}
+    </button>
+  );
+};
+
+export default ExportButton;


### PR DESCRIPTION
### Depends on: PR https://github.com/AquiLLM/AquiLLM/pull/159
### Do not merge before PR https://github.com/AquiLLM/AquiLLM/pull/159, once PR https://github.com/AquiLLM/AquiLLM/pull/159 is merged I will adjust the base of this Pull Request to development. (the reason that isn't the case now is so this PR only shows the work done for this PR, not also the work it relies on)

Adds the ExportButton React component for downloading filtered feedback dashboard results as CSV. This PR builds the export URL from the current filter query string and triggers a  file download. It does not fetch the full export into frontend memory. Instead of that, the browser follows the export URL directly, letting the backend streaming response and the Content-Disposition filename to control the download.
