### PR TITLE
p30: Register feedback dashboard React component

### DIFF
--- a/react/src/main.tsx
+++ b/react/src/main.tsx
@@ -15,6 +15,7 @@ import UserSettings from './components/UserSettings';
 import ChatFileUpload from './components/ChatFileUpload';
 import BugReportButton from './components/BugReportButton';
 import BugReportsAdmin from './components/BugReportsAdmin';
+import FeedbackDashboard from './components/FeedbackDashboard';
 // Type for the components mapping
 type ComponentsMap = {
   [key: string]: React.ComponentType<any>;
@@ -49,6 +50,7 @@ window.mountReactComponent = (
     ChatFileUpload: ChatFileUpload,
     BugReportButton: BugReportButton,
     BugReportsAdmin: BugReportsAdmin,
+    FeedbackDashboard: FeedbackDashboard,
     // Add other components here
   };
   


### PR DESCRIPTION
### Depends on: PR #167 
### Do not merge before PR #167, once PR #167 is merged I will adjust the base of this Pull Request to development. (the reason that isn't the case now is so this PR only shows the work done for this PR, not also the work it relies on)

Registers the FeedbackDashboard React component with the global mountReactComponent registry. This PR adds a FeedbackDashboard import to react/src/main.tsx and registers it in the component map so that the Django feedback_dashboard.html template can mount it by name.
