### PR TITLE
p38: Add feedback dashboard page permission tests

### DIFF
--- a/aquillm/apps/platform_admin/tests/test_feedback_dashboard_page_permissions.py
+++ b/aquillm/apps/platform_admin/tests/test_feedback_dashboard_page_permissions.py
@@ -1,0 +1,77 @@
+"""Permission tests for the feedback dashboard page."""
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+
+User = get_user_model()
+
+
+def make_superuser(username: str = "pageadmin") -> User:
+    return User.objects.create_superuser(
+        username=username,
+        email=f"{username}@test.com",
+        password="testpass123",
+    )
+
+
+def make_staff_user(username: str = "pagestaff") -> User:
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@test.com",
+        password="testpass123",
+        is_staff=True,
+    )
+
+
+def make_regular_user(username: str = "pageregular") -> User:
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@test.com",
+        password="testpass123",
+    )
+
+
+class FeedbackDashboardPagePermissionTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.superuser = make_superuser()
+        self.staff_user = make_staff_user()
+        self.regular_user = make_regular_user()
+        self.url = reverse("feedback_dashboard")
+
+    def test_unauthenticated_user_redirects_to_login(self):
+        resp = self.client.get(self.url)
+
+        self.assertIn(resp.status_code, [301, 302])
+        self.assertIn("login", resp["Location"].lower())
+
+    def test_regular_user_is_forbidden(self):
+        self.client.login(username="pageregular", password="testpass123")
+
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_staff_user_is_forbidden(self):
+        self.client.login(username="pagestaff", password="testpass123")
+
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_superuser_gets_page(self):
+        self.client.login(username="pageadmin", password="testpass123")
+
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_superuser_page_uses_dashboard_template(self):
+        self.client.login(username="pageadmin", password="testpass123")
+
+        resp = self.client.get(self.url)
+        self.assertTemplateUsed(resp, "aquillm/feedback_dashboard.html")
+
+    def test_superuser_page_extends_base_template(self):
+        self.client.login(username="pageadmin", password="testpass123")
+
+        resp = self.client.get(self.url)
+        self.assertTemplateUsed(resp, "aquillm/base.html")


### PR DESCRIPTION
### This PR is part of the stacked feedback dashboard implementation and depends on p10 because it tests the dashboard page route and template. The tests verify that unauthenticated users are redirected to login, regular users are forbidden, staff users who aren't superusers are forbidden, and superusers can access the page. It also checks that the superuser page renders the feedback dashboard template and extends the base template.

Adds focused permission tests for the feedback dashboard page.
