### PR TITLE
fix: serialize collection timestamps in list/create API (#130)

### DIFF
--- a/aquillm/apps/collections/tests/test_collection_api.py
+++ b/aquillm/apps/collections/tests/test_collection_api.py
@@ -229,3 +229,37 @@ def test_collection_permissions_post_leaves_non_figure_children_untouched(client
     assert response.status_code == 200
 
     assert CollectionPermission.objects.filter(collection=other_child, user=owner, permission="MANAGE").exists()
+
+
+@pytest.mark.django_db
+def test_collections_list_includes_created_and_updated_at(client):
+    user = User.objects.create_user(username="collections-list-user", password="pw12345")
+    collection = Collection.objects.create(name="Has Timestamps")
+    CollectionPermission.objects.create(user=user, collection=collection, permission="VIEW")
+
+    assert client.login(username="collections-list-user", password="pw12345")
+    response = client.get(reverse("api_collections"))
+
+    assert response.status_code == 200
+    payload = response.json()
+    listed = next(item for item in payload["collections"] if item["id"] == collection.id)
+    assert listed["created_at"] == collection.created_at.isoformat()
+    assert listed["updated_at"] == collection.updated_at.isoformat()
+
+
+@pytest.mark.django_db
+def test_collections_create_response_includes_created_and_updated_at(client):
+    user = User.objects.create_user(username="collections-create-user", password="pw12345")
+    assert client.login(username="collections-create-user", password="pw12345")
+
+    response = client.post(
+        reverse("api_collections"),
+        data=json.dumps({"name": "Brand New"}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    created = Collection.objects.get(id=payload["id"])
+    assert payload["created_at"] == created.created_at.isoformat()
+    assert payload["updated_at"] == created.updated_at.isoformat()

--- a/aquillm/apps/collections/views/api.py
+++ b/aquillm/apps/collections/views/api.py
@@ -87,6 +87,8 @@ def collections(request):
                 'path': collection.get_path(),
                 'document_count': collection.document_count(),
                 'children_count': collection.children.count(),
+                'created_at': collection.created_at.isoformat(),
+                'updated_at': collection.updated_at.isoformat(),
                 'permission': 'MANAGE'
             })
 
@@ -101,6 +103,8 @@ def collections(request):
             'path': colperm.collection.get_path(),
             'document_count': colperm.collection.document_count(),
             'children_count': colperm.collection.children.count(),
+            'created_at': colperm.collection.created_at.isoformat(),
+            'updated_at': colperm.collection.updated_at.isoformat(),
             'permission': colperm.permission
         })
     return JsonResponse({"collections": collections_list})

--- a/react/src/components/collectionsPageMap.ts
+++ b/react/src/components/collectionsPageMap.ts
@@ -21,8 +21,8 @@ export function mapCollectionFromApi(col: {
     children: Array.isArray(col.children) ? (col.children as Collection[]) : [],
     document_count: col.document_count ?? 0,
     children_count: col.children_count ?? 0,
-    created_at: new Date(col.created_at || new Date()).toLocaleString(),
-    updated_at: new Date(col.updated_at || new Date()).toISOString(),
+    created_at: col.created_at ?? '',
+    updated_at: col.updated_at ?? '',
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #130 — collection cards in the collections pane were showing today's date for every collection.

Root cause was a backend/frontend contract mismatch. The `Collection` model has `created_at`/`updated_at` set via `auto_now_add`/`auto_now`, but the GET `/api/collections` list endpoint and POST create response weren't serializing those fields. The frontend mapper then defaulted the missing values to `new Date()` — today — and rendered that on every card.

- `apps/collections/views/api.py`: include `created_at`/`updated_at` ISO strings in both the list response and the create response, matching the shape already used by the per-collection detail endpoint.
- `react/src/components/collectionsPageMap.ts`: drop the `new Date()` fallback. Empty string surfaces missing data instead of fabricating today, so future regressions render `Invalid Date` rather than silently passing.
- Add two regression tests in `apps/collections/tests/test_collection_api.py` asserting the timestamps appear in both payloads.

## Test plan

- [x] `pytest apps/collections/tests/` — 16 passed
- [ ] Manual: open collections pane in browser, confirm "Created:" line shows the correct historical date for collections created on prior days, not today