### PR TITLE
feat(ui): show app version at bottom of sidebar

### DIFF
--- a/aquillm/aquillm/context_processors.py
+++ b/aquillm/aquillm/context_processors.py
@@ -1,6 +1,8 @@
 """Template context processors: navigation, URLs exposed to the client, theme."""
 from __future__ import annotations
 
+import tomllib
+
 import structlog
 from pathlib import Path
 from typing import Any
@@ -11,6 +13,19 @@ from django.urls import NoReverseMatch, reverse
 from .models import UserSettings, WSConversation
 
 logger = structlog.stdlib.get_logger(__name__)
+
+
+def _load_app_version() -> str:
+    pyproject = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
+    try:
+        with pyproject.open("rb") as f:
+            return tomllib.load(f)["project"]["version"]
+    except (OSError, KeyError, tomllib.TOMLDecodeError) as exc:
+        logger.warning("Could not read app version from %s: %s", pyproject, exc)
+        return ""
+
+
+_APP_VERSION = _load_app_version()
 
 _PLACEHOLDER_DOC_ID = UUID("00000000-0000-0000-0000-000000000001")
 
@@ -135,6 +150,10 @@ def theme_settings(request):
     else:
         settings = None
     return {"user_theme_settings": settings}
+
+
+def app_version(request):
+    return {"app_version": _APP_VERSION}
 
 
 def react_bundle_version(request):

--- a/aquillm/aquillm/settings.py
+++ b/aquillm/aquillm/settings.py
@@ -206,6 +206,7 @@ TEMPLATES = [
                 "aquillm.context_processors.page_urls",
                 "aquillm.context_processors.react_bundle_version",
                 "aquillm.context_processors.theme_settings",
+                "aquillm.context_processors.app_version",
             ],
         },
     },

--- a/aquillm/templates/aquillm/base.html
+++ b/aquillm/templates/aquillm/base.html
@@ -257,6 +257,11 @@
                         {% endif %}
                     </div>
                 </div>
+                {% if app_version %}
+                <div class="text-xs pl-[8px] pr-[8px] py-[8px] text-text-normal opacity-50 select-none">
+                    v{{ app_version }}
+                </div>
+                {% endif %}
             </div>
 
             <!-- Page Content -->


### PR DESCRIPTION
## Summary
- Adds an `app_version` context processor that reads the version from `pyproject.toml` once at module load (Python 3.12 `tomllib`), making `pyproject.toml` the single source of truth.
- Registers the processor in Django `TEMPLATES` settings.
- Renders the version as a muted `text-xs` footer pinned at the bottom of the left sidebar, outside the scrollable nav list.

## Test plan
- [ ] Load any authenticated page and confirm `v0.1.0` shows at the bottom of the sidebar in light/muted text.
- [ ] Toggle the sidebar collapse and confirm the footer hides/shows with the rest of the sidebar.
- [ ] Bump `version` in `pyproject.toml`, restart the server, and confirm the footer reflects the new value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)