### PR TITLE
feat(chat): tag messages with app version

### DIFF
--- a/aquillm/apps/chat/migrations/0004_message_app_version.py
+++ b/aquillm/apps/chat/migrations/0004_message_app_version.py
@@ -1,0 +1,17 @@
+"""Tag chat messages with the app version at write time; backfill legacy rows."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("apps_chat", "0003_wsconversation_selected_collection_ids"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="message",
+            name="app_version",
+            field=models.CharField(default="pre-0.1.0", max_length=20),
+        ),
+    ]

--- a/aquillm/apps/chat/models/message.py
+++ b/aquillm/apps/chat/models/message.py
@@ -3,7 +3,7 @@ import uuid
 
 from django.db import models
 
-from aquillm.app_version import APP_VERSION
+from aquillm.app_version import current_app_version
 
 from .conversation import WSConversation
 
@@ -21,7 +21,7 @@ class Message(models.Model):
     feedback_submitted_at = models.DateTimeField(null=True, blank=True, db_index=True)
     sequence_number = models.PositiveIntegerField()
     created_at = models.DateTimeField(auto_now_add=True)
-    app_version = models.CharField(max_length=20, default="pre-0.1.0")
+    app_version = models.CharField(max_length=20, default=current_app_version)
 
     # AssistantMessage-specific fields
     model = models.CharField(max_length=100, null=True, blank=True)
@@ -42,8 +42,3 @@ class Message(models.Model):
         db_table = 'aquillm_message'
         ordering = ['conversation', 'sequence_number']
         indexes = [models.Index(fields=['rating'])]
-
-    def save(self, *args, **kwargs):
-        if self._state.adding and self.app_version == "pre-0.1.0" and APP_VERSION:
-            self.app_version = APP_VERSION
-        super().save(*args, **kwargs)

--- a/aquillm/apps/chat/models/message.py
+++ b/aquillm/apps/chat/models/message.py
@@ -3,6 +3,8 @@ import uuid
 
 from django.db import models
 
+from aquillm.app_version import APP_VERSION
+
 from .conversation import WSConversation
 
 
@@ -19,6 +21,7 @@ class Message(models.Model):
     feedback_submitted_at = models.DateTimeField(null=True, blank=True, db_index=True)
     sequence_number = models.PositiveIntegerField()
     created_at = models.DateTimeField(auto_now_add=True)
+    app_version = models.CharField(max_length=20, default="pre-0.1.0")
 
     # AssistantMessage-specific fields
     model = models.CharField(max_length=100, null=True, blank=True)
@@ -39,3 +42,8 @@ class Message(models.Model):
         db_table = 'aquillm_message'
         ordering = ['conversation', 'sequence_number']
         indexes = [models.Index(fields=['rating'])]
+
+    def save(self, *args, **kwargs):
+        if self._state.adding and self.app_version == "pre-0.1.0" and APP_VERSION:
+            self.app_version = APP_VERSION
+        super().save(*args, **kwargs)

--- a/aquillm/aquillm/app_version.py
+++ b/aquillm/aquillm/app_version.py
@@ -20,3 +20,7 @@ def _load() -> str:
 
 
 APP_VERSION = _load()
+
+
+def current_app_version() -> str:
+    return APP_VERSION

--- a/aquillm/aquillm/app_version.py
+++ b/aquillm/aquillm/app_version.py
@@ -1,0 +1,22 @@
+"""Read the project version from pyproject.toml once at import time."""
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import structlog
+
+logger = structlog.stdlib.get_logger(__name__)
+
+
+def _load() -> str:
+    pyproject = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
+    try:
+        with pyproject.open("rb") as f:
+            return tomllib.load(f)["project"]["version"]
+    except (OSError, KeyError, tomllib.TOMLDecodeError) as exc:
+        logger.warning("Could not read app version from %s: %s", pyproject, exc)
+        return ""
+
+
+APP_VERSION = _load()

--- a/aquillm/aquillm/context_processors.py
+++ b/aquillm/aquillm/context_processors.py
@@ -1,8 +1,6 @@
 """Template context processors: navigation, URLs exposed to the client, theme."""
 from __future__ import annotations
 
-import tomllib
-
 import structlog
 from pathlib import Path
 from typing import Any
@@ -10,22 +8,10 @@ from uuid import UUID
 
 from django.urls import NoReverseMatch, reverse
 
+from .app_version import APP_VERSION
 from .models import UserSettings, WSConversation
 
 logger = structlog.stdlib.get_logger(__name__)
-
-
-def _load_app_version() -> str:
-    pyproject = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
-    try:
-        with pyproject.open("rb") as f:
-            return tomllib.load(f)["project"]["version"]
-    except (OSError, KeyError, tomllib.TOMLDecodeError) as exc:
-        logger.warning("Could not read app version from %s: %s", pyproject, exc)
-        return ""
-
-
-_APP_VERSION = _load_app_version()
 
 _PLACEHOLDER_DOC_ID = UUID("00000000-0000-0000-0000-000000000001")
 
@@ -153,7 +139,7 @@ def theme_settings(request):
 
 
 def app_version(request):
-    return {"app_version": _APP_VERSION}
+    return {"app_version": APP_VERSION}
 
 
 def react_bundle_version(request):


### PR DESCRIPTION
## Summary
- Adds an `app_version` column to `Message`, defaulted to `current_app_version()` so new rows are stamped with the version at write time.
- Hand-written migration backfills all existing rows with `pre-0.1.0`.
- Extracts the pyproject version loader into `aquillm/app_version.py` to avoid a circular import (`message` → `context_processors` → `aquillm.models` → `apps.chat.models`).
- Verified in dev: messages created before this change → `pre-0.1.0` (324 rows backfilled), new messages → `0.1.0`.

Stacks on top of #211 (sidebar version footer).

## Test plan
- [ ] After deploying, send a message in a conversation and confirm the row's `app_version` matches `pyproject.toml`.
- [ ] Bump `version` in `pyproject.toml`, restart the web container, send a new message, and confirm it gets stamped with the new value.
- [ ] Confirm legacy rows still read `pre-0.1.0` (no accidental rewrites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)