### PR TITLE
feat(skills): per-collection Collection Notes (phase 1)

### DIFF
--- a/aquillm/apps/chat/services/skills_runtime.py
+++ b/aquillm/apps/chat/services/skills_runtime.py
@@ -7,7 +7,12 @@ from typing import Any
 
 from django.conf import settings
 
-from apps.skills.services.runtime import aload_user_skill_bodies, load_user_skill_bodies
+from apps.skills.services.runtime import (
+    aload_collection_skill_bodies,
+    aload_user_skill_bodies,
+    load_collection_skill_bodies,
+    load_user_skill_bodies,
+)
 from aquillm.llm import LLMTool
 from lib.skills import (
     collect_system_prompt_extras,
@@ -65,12 +70,19 @@ def build_skill_tools(consumer: Any) -> list[LLMTool]:
     return collect_tools(_resolved_modules(), ctx)
 
 
-def _compose_base_system(base: str, py_extra: str, md_extra: str, db_extra: str) -> str:
-    extra_parts = [s for s in (py_extra, md_extra, db_extra) if s]
+def _compose_base_system(
+    base: str, py_extra: str, md_extra: str, db_extra: str, coll_extra: str
+) -> str:
+    extra_parts = [s for s in (py_extra, md_extra, db_extra, coll_extra) if s]
     if not extra_parts:
         return base
     extra = "\n\n---\n\n".join(extra_parts)
     return f"{base.rstrip()}\n\n{extra}"
+
+
+def _convo_collection_ids(consumer: Any) -> list[int]:
+    raw = getattr(consumer.db_convo, "selected_collection_ids", None) or []
+    return [int(x) for x in raw if isinstance(x, (int, str)) and str(x).strip().isdigit()]
 
 
 def effective_base_system_for_memory(consumer: Any) -> str:
@@ -89,7 +101,8 @@ def effective_base_system_for_memory(consumer: Any) -> str:
     py_extra = collect_system_prompt_extras(_resolved_modules(), ctx).strip()
     md_extra = load_markdown_prompt_bodies(_markdown_skills_root()).strip()
     db_extra = load_user_skill_bodies(consumer.user.id).strip()
-    return _compose_base_system(base, py_extra, md_extra, db_extra)
+    coll_extra = load_collection_skill_bodies(_convo_collection_ids(consumer)).strip()
+    return _compose_base_system(base, py_extra, md_extra, db_extra, coll_extra)
 
 
 async def aeffective_base_system_for_memory(consumer: Any) -> str:
@@ -105,7 +118,8 @@ async def aeffective_base_system_for_memory(consumer: Any) -> str:
     py_extra = collect_system_prompt_extras(_resolved_modules(), ctx).strip()
     md_extra = load_markdown_prompt_bodies(_markdown_skills_root()).strip()
     db_extra = (await aload_user_skill_bodies(consumer.user.id)).strip()
-    return _compose_base_system(base, py_extra, md_extra, db_extra)
+    coll_extra = (await aload_collection_skill_bodies(_convo_collection_ids(consumer))).strip()
+    return _compose_base_system(base, py_extra, md_extra, db_extra, coll_extra)
 
 
 __all__ = [

--- a/aquillm/apps/skills/migrations/0002_collectionskill.py
+++ b/aquillm/apps/skills/migrations/0002_collectionskill.py
@@ -1,0 +1,46 @@
+"""Adds the CollectionSkill table (one markdown notes doc per collection)."""
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("apps_skills", "0001_initial"),
+        ("apps_collections", "0001_initial_from_aquillm"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="CollectionSkill",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("body", models.TextField()),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "collection",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="skill",
+                        to="apps_collections.collection",
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "aquillm_collectionskill",
+            },
+        ),
+    ]

--- a/aquillm/apps/skills/models/__init__.py
+++ b/aquillm/apps/skills/models/__init__.py
@@ -1,3 +1,4 @@
+from .collection_skill import CollectionSkill
 from .skill import Skill
 
-__all__ = ["Skill"]
+__all__ = ["CollectionSkill", "Skill"]

--- a/aquillm/apps/skills/models/collection_skill.py
+++ b/aquillm/apps/skills/models/collection_skill.py
@@ -1,0 +1,33 @@
+"""CollectionSkill model: per-collection markdown notes merged into the chat system prompt.
+
+One row per collection. Body is the markdown "Collection Notes" content owners
+write to teach AquiLLM domain-specific facts (author lists, terminology,
+project conventions, etc.). Absence of a row means the collection has no notes
+and behaves exactly as before.
+"""
+from django.contrib.auth.models import User
+from django.db import models
+
+from apps.collections.models import Collection
+
+
+MAX_BODY_LENGTH = 16_000
+
+
+class CollectionSkill(models.Model):
+    collection = models.OneToOneField(
+        Collection, on_delete=models.CASCADE, related_name="skill"
+    )
+    body = models.TextField()
+    updated_by = models.ForeignKey(
+        User, on_delete=models.SET_NULL, null=True, blank=True, related_name="+"
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        app_label = "apps_skills"
+        db_table = "aquillm_collectionskill"
+
+    def __str__(self) -> str:
+        return f"CollectionSkill({self.collection_id})"

--- a/aquillm/apps/skills/services/runtime.py
+++ b/aquillm/apps/skills/services/runtime.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from channels.db import database_sync_to_async
 from django.conf import settings
 
-from apps.skills.models import Skill
+from apps.skills.models import CollectionSkill, Skill
 
 
 _SECTION_SEP = "\n\n---\n\n"
@@ -48,4 +48,49 @@ async def aload_user_skill_bodies(user_id: int) -> str:
     return _format_skills(await _afetch_user_skills(user_id))
 
 
-__all__ = ["load_user_skill_bodies", "aload_user_skill_bodies"]
+def _format_collection_skills(rows) -> str:
+    parts: list[str] = []
+    for row in rows:
+        body = (row.body or "").strip()
+        if not body:
+            continue
+        parts.append(f"## Collection notes — {row.collection.name}\n\n{body}")
+    if not parts:
+        return ""
+    return _SECTION_SEP.join(parts)
+
+
+def _fetch_collection_skills(collection_ids):
+    if not collection_ids:
+        return []
+    return list(
+        CollectionSkill.objects
+        .select_related("collection")
+        .filter(collection_id__in=collection_ids)
+        .order_by("collection__name")
+    )
+
+
+_afetch_collection_skills = database_sync_to_async(_fetch_collection_skills)
+
+
+def load_collection_skill_bodies(collection_ids) -> str:
+    """Sync loader for per-collection notes selected in a conversation."""
+    if not getattr(settings, "SKILLS_ENABLED", False):
+        return ""
+    return _format_collection_skills(_fetch_collection_skills(collection_ids))
+
+
+async def aload_collection_skill_bodies(collection_ids) -> str:
+    """Async loader for per-collection notes selected in a conversation."""
+    if not getattr(settings, "SKILLS_ENABLED", False):
+        return ""
+    return _format_collection_skills(await _afetch_collection_skills(collection_ids))
+
+
+__all__ = [
+    "load_user_skill_bodies",
+    "aload_user_skill_bodies",
+    "load_collection_skill_bodies",
+    "aload_collection_skill_bodies",
+]

--- a/aquillm/apps/skills/tests/test_collection_skill.py
+++ b/aquillm/apps/skills/tests/test_collection_skill.py
@@ -1,0 +1,214 @@
+"""Tests for per-collection Collection Notes: loader + API permission checks."""
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client, override_settings
+
+from apps.collections.models import Collection, CollectionPermission
+from apps.skills.models import CollectionSkill
+from apps.skills.services.runtime import (
+    aload_collection_skill_bodies,
+    load_collection_skill_bodies,
+)
+
+User = get_user_model()
+
+
+# ---- fixtures --------------------------------------------------------------
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user(username="owner", password="pw")
+
+
+@pytest.fixture
+def editor(db):
+    return User.objects.create_user(username="editor", password="pw")
+
+
+@pytest.fixture
+def viewer(db):
+    return User.objects.create_user(username="viewer", password="pw")
+
+
+@pytest.fixture
+def stranger(db):
+    return User.objects.create_user(username="stranger", password="pw")
+
+
+@pytest.fixture
+def collection(owner, editor, viewer):
+    c = Collection.objects.create(name="papers")
+    CollectionPermission.objects.create(user=owner, collection=c, permission="MANAGE")
+    CollectionPermission.objects.create(user=editor, collection=c, permission="EDIT")
+    CollectionPermission.objects.create(user=viewer, collection=c, permission="VIEW")
+    return c
+
+
+def _client(user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+# ---- loader ----------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=True)
+def test_loader_empty_when_no_row(collection):
+    assert load_collection_skill_bodies([collection.id]) == ""
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=True)
+def test_loader_empty_when_collection_list_empty():
+    assert load_collection_skill_bodies([]) == ""
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=False)
+def test_loader_empty_when_feature_disabled(collection):
+    CollectionSkill.objects.create(collection=collection, body="alpha")
+    assert load_collection_skill_bodies([collection.id]) == ""
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=True)
+def test_loader_includes_collection_name_header(collection):
+    CollectionSkill.objects.create(collection=collection, body="The authors are X and Y.")
+    out = load_collection_skill_bodies([collection.id])
+    assert "## Collection notes — papers" in out
+    assert "The authors are X and Y." in out
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=True)
+def test_loader_concatenates_multiple_collections(owner):
+    c1 = Collection.objects.create(name="alpha-coll")
+    c2 = Collection.objects.create(name="beta-coll")
+    CollectionSkill.objects.create(collection=c1, body="alpha body")
+    CollectionSkill.objects.create(collection=c2, body="beta body")
+    out = load_collection_skill_bodies([c1.id, c2.id])
+    assert "alpha body" in out
+    assert "beta body" in out
+    assert "\n\n---\n\n" in out  # section separator
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=True)
+def test_loader_skips_empty_bodies(collection):
+    CollectionSkill.objects.create(collection=collection, body="   ")
+    assert load_collection_skill_bodies([collection.id]) == ""
+
+
+@pytest.mark.django_db(transaction=True)
+@override_settings(SKILLS_ENABLED=True)
+async def test_async_loader_works(collection):
+    await CollectionSkill.objects.acreate(collection=collection, body="async body")
+    out = await aload_collection_skill_bodies([collection.id])
+    assert "async body" in out
+
+
+# ---- API: permission gates -------------------------------------------------
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=True)
+def test_get_returns_empty_shape_when_no_row(collection, owner):
+    r = _client(owner).get(f"/api/collections/{collection.id}/skill/")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["body"] == ""
+    assert data["exists"] is False
+    assert data["max_body_length"] > 0
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=True)
+def test_get_allowed_for_editor(collection, editor):
+    r = _client(editor).get(f"/api/collections/{collection.id}/skill/")
+    assert r.status_code == 200
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=True)
+def test_get_forbidden_for_viewer(collection, viewer):
+    """VIEW alone is not enough to see the notes text (conservative default)."""
+    r = _client(viewer).get(f"/api/collections/{collection.id}/skill/")
+    assert r.status_code == 403
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=True)
+def test_get_forbidden_for_stranger(collection, stranger):
+    r = _client(stranger).get(f"/api/collections/{collection.id}/skill/")
+    assert r.status_code == 403
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=True)
+def test_put_upserts_for_manager(collection, owner):
+    r = _client(owner).put(
+        f"/api/collections/{collection.id}/skill/",
+        data=json.dumps({"body": "first revision"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert CollectionSkill.objects.get(collection=collection).body == "first revision"
+
+    # second PUT should update, not duplicate
+    r2 = _client(owner).put(
+        f"/api/collections/{collection.id}/skill/",
+        data=json.dumps({"body": "second revision"}),
+        content_type="application/json",
+    )
+    assert r2.status_code == 200
+    assert CollectionSkill.objects.filter(collection=collection).count() == 1
+    assert CollectionSkill.objects.get(collection=collection).body == "second revision"
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=True)
+def test_put_forbidden_for_editor(collection, editor):
+    r = _client(editor).put(
+        f"/api/collections/{collection.id}/skill/",
+        data=json.dumps({"body": "should not save"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 403
+    assert not CollectionSkill.objects.filter(collection=collection).exists()
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=True)
+def test_put_rejects_oversized_body(collection, owner):
+    big = "x" * 17_000  # over the 16 KB cap
+    r = _client(owner).put(
+        f"/api/collections/{collection.id}/skill/",
+        data=json.dumps({"body": big}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+    assert not CollectionSkill.objects.filter(collection=collection).exists()
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=True)
+def test_put_records_updated_by(collection, owner):
+    _client(owner).put(
+        f"/api/collections/{collection.id}/skill/",
+        data=json.dumps({"body": "by-owner"}),
+        content_type="application/json",
+    )
+    cs = CollectionSkill.objects.get(collection=collection)
+    assert cs.updated_by_id == owner.id
+
+
+@pytest.mark.django_db
+@override_settings(SKILLS_ENABLED=False)
+def test_api_404_when_feature_disabled(collection, owner):
+    r = _client(owner).get(f"/api/collections/{collection.id}/skill/")
+    assert r.status_code == 404

--- a/aquillm/apps/skills/urls.py
+++ b/aquillm/apps/skills/urls.py
@@ -10,9 +10,19 @@ app_name = "skills"
 api_urlpatterns = [
     path("skills/", api_views.skills_list_create, name="api_skills_list_create"),
     path("skills/<int:skill_id>/", api_views.skill_detail, name="api_skill_detail"),
+    path(
+        "collections/<int:collection_id>/skill/",
+        api_views.collection_skill_detail,
+        name="api_collection_skill_detail",
+    ),
 ]
 
 # Page URL patterns (included under /aquillm/)
 page_urlpatterns = [
     path("skills/", page_views.skills_page, name="skills_page"),
+    path(
+        "collections/<int:collection_id>/notes/",
+        page_views.collection_notes_page,
+        name="collection_notes_page",
+    ),
 ]

--- a/aquillm/apps/skills/views/api.py
+++ b/aquillm/apps/skills/views/api.py
@@ -9,7 +9,9 @@ from django.db import IntegrityError
 from django.http import HttpRequest, JsonResponse
 from django.views.decorators.http import require_http_methods
 
-from apps.skills.models import Skill
+from apps.collections.models import Collection
+from apps.skills.models import CollectionSkill, Skill
+from apps.skills.models.collection_skill import MAX_BODY_LENGTH as COLLECTION_SKILL_MAX_BODY
 
 
 MAX_NAME_LENGTH = 120
@@ -137,4 +139,70 @@ def skill_detail(request: HttpRequest, skill_id: int) -> JsonResponse:
     return JsonResponse(_serialize(skill))
 
 
-__all__ = ["skills_list_create", "skill_detail"]
+def _serialize_collection_skill(cs: CollectionSkill | None, collection: Collection) -> dict:
+    if cs is None:
+        return {
+            "collection_id": collection.id,
+            "collection_name": collection.name,
+            "body": "",
+            "updated_at": None,
+            "updated_by": None,
+            "exists": False,
+            "max_body_length": COLLECTION_SKILL_MAX_BODY,
+        }
+    return {
+        "collection_id": collection.id,
+        "collection_name": collection.name,
+        "body": cs.body,
+        "updated_at": cs.updated_at.isoformat() if cs.updated_at else None,
+        "updated_by": cs.updated_by.username if cs.updated_by else None,
+        "exists": True,
+        "max_body_length": COLLECTION_SKILL_MAX_BODY,
+    }
+
+
+@login_required
+@require_http_methods(["GET", "PUT"])
+def collection_skill_detail(request: HttpRequest, collection_id: int) -> JsonResponse:
+    """Read or upsert the Collection Notes for a single collection.
+
+    Permission rules:
+      - GET requires EDIT or higher on the collection.
+      - PUT requires MANAGE on the collection.
+    PUT is upsert: creates the row if it does not exist, updates otherwise.
+    """
+    if not getattr(settings, "SKILLS_ENABLED", False):
+        return JsonResponse({"error": "Skills feature is disabled"}, status=404)
+
+    try:
+        collection = Collection.objects.get(pk=collection_id)
+    except Collection.DoesNotExist:
+        return JsonResponse({"error": "Collection not found"}, status=404)
+
+    if request.method == "GET":
+        if not collection.user_can_edit(request.user):
+            return JsonResponse({"error": "Forbidden"}, status=403)
+        cs = CollectionSkill.objects.filter(collection=collection).first()
+        return JsonResponse(_serialize_collection_skill(cs, collection))
+
+    # PUT
+    if not collection.user_can_manage(request.user):
+        return JsonResponse({"error": "Forbidden"}, status=403)
+    payload = _parse_payload(request)
+    if isinstance(payload, JsonResponse):
+        return payload
+    body = payload.get("body", "")
+    if not isinstance(body, str):
+        return JsonResponse({"error": "body must be a string"}, status=400)
+    if len(body) > COLLECTION_SKILL_MAX_BODY:
+        return JsonResponse(
+            {"error": f"body too long (max {COLLECTION_SKILL_MAX_BODY} chars)"}, status=400
+        )
+    cs, _ = CollectionSkill.objects.update_or_create(
+        collection=collection,
+        defaults={"body": body, "updated_by": request.user},
+    )
+    return JsonResponse(_serialize_collection_skill(cs, collection))
+
+
+__all__ = ["skills_list_create", "skill_detail", "collection_skill_detail"]

--- a/aquillm/apps/skills/views/pages.py
+++ b/aquillm/apps/skills/views/pages.py
@@ -1,9 +1,12 @@
 """Page views for the skills feature."""
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.http import Http404, HttpRequest, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse, HttpResponseForbidden
 from django.shortcuts import render
+from django.urls import reverse
 from django.views.decorators.http import require_http_methods
+
+from apps.collections.models import Collection
 
 
 @login_required
@@ -18,4 +21,32 @@ def skills_page(request: HttpRequest) -> HttpResponse:
     return render(request, "aquillm/skills.html")
 
 
-__all__ = ["skills_page"]
+@login_required
+@require_http_methods(["GET"])
+def collection_notes_page(request: HttpRequest, collection_id: int) -> HttpResponse:
+    """Render the per-collection notes editor page.
+
+    Requires MANAGE on the collection; lower-permission users get 403. The
+    React island reads the collection id/name from the mount element's data
+    attributes — no extra context fetch on first paint.
+    """
+    if not getattr(settings, "SKILLS_ENABLED", False):
+        raise Http404("Skills feature is disabled")
+    try:
+        collection = Collection.objects.get(pk=collection_id)
+    except Collection.DoesNotExist:
+        raise Http404("Collection not found")
+    if not collection.user_can_manage(request.user):
+        return HttpResponseForbidden("You do not have permission to edit this collection's notes.")
+    return render(
+        request,
+        "aquillm/collection_notes.html",
+        {
+            "collection_id": collection.id,
+            "collection_name": collection.name,
+            "collection_url": reverse("collection", args=[collection.id]),
+        },
+    )
+
+
+__all__ = ["skills_page", "collection_notes_page"]

--- a/aquillm/aquillm/apps.py
+++ b/aquillm/aquillm/apps.py
@@ -65,7 +65,14 @@ class AquillmConfig(AppConfig):
     get_embedding = None
     llm_interface: LLMInterface = None
     system_prompt = (
-        "You are a helpful assistant embedded in a retrieval augmented generation system.\n"
+        "You are an assistant with access to a document search tool called vector_search "
+        "and related tools for listing and opening documents. When the user asks a factual "
+        "or substantive question — especially about a specific project, codebase, product, "
+        "person, paper, or topic — CALL vector_search FIRST to retrieve passages from their "
+        "uploaded documents before answering. Do not rely on your training data for such "
+        "questions; answer from retrieved sources and cite them. Only skip the tool for "
+        "casual chat, greetings, or clearly meta questions about yourself. If a search "
+        "returns no relevant results, say so plainly — do not invent facts.\n"
         "For math, use KaTeX: $..$ for inline, $$..$$ for display. Never use \\(...\\) or \\[...\\] delimiters. Never duplicate math as plaintext."
     )
 

--- a/aquillm/templates/aquillm/collection_notes.html
+++ b/aquillm/templates/aquillm/collection_notes.html
@@ -1,0 +1,18 @@
+{% extends "aquillm/base.html" %}
+{% load static %}
+
+{% block title %}AquiLLM -- Collection Notes -- {{ collection_name }}{% endblock %}
+
+{% block content %}
+  <div
+    id="collection-notes-page"
+    class="h-full"
+    data-collection-id="{{ collection_id }}"
+    data-collection-name="{{ collection_name }}"
+    data-collection-url="{{ collection_url }}"
+  ></div>
+{% endblock %}
+
+{% block scripts %}
+  <script type="module" src="{% static 'js/dist/collection_notes.js' %}{% if react_bundle_version %}?v={{ react_bundle_version }}{% endif %}"></script>
+{% endblock %}

--- a/react/src/collection_notes_entry.tsx
+++ b/react/src/collection_notes_entry.tsx
@@ -1,0 +1,42 @@
+// Separate Vite entry for the /aquillm/collections/<id>/notes/ page.
+//
+// See `vite.config.skills.ts` for why this lives in its own bundle (Monaco
+// requires ES-module loading, which the main app's classic <script> tag can't
+// handle). This bundle is loaded as `<script type="module">` only on the
+// Collection Notes page; main.js stays untouched.
+import React, { Suspense } from 'react';
+import { createRoot } from 'react-dom/client';
+
+const CollectionNotesPage = React.lazy(
+  () => import('./features/skills/components/CollectionNotesPage'),
+);
+
+function mount() {
+  const el = document.getElementById('collection-notes-page');
+  if (!el) {
+    console.error("Element 'collection-notes-page' not found");
+    return;
+  }
+  const collectionId = Number(el.dataset.collectionId);
+  const collectionName = el.dataset.collectionName ?? '';
+  const collectionUrl = el.dataset.collectionUrl ?? '/aquillm/collections/';
+  if (!Number.isFinite(collectionId) || collectionId <= 0) {
+    console.error('Invalid collection-id data attribute on mount element');
+    return;
+  }
+  createRoot(el).render(
+    <Suspense fallback={null}>
+      <CollectionNotesPage
+        collectionId={collectionId}
+        collectionName={collectionName}
+        collectionUrl={collectionUrl}
+      />
+    </Suspense>,
+  );
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', mount);
+} else {
+  mount();
+}

--- a/react/src/components/CollectionSettingsMenu.tsx
+++ b/react/src/components/CollectionSettingsMenu.tsx
@@ -11,6 +11,8 @@ interface CollectionSettingsMenuProps {
   onMove: (collection: Collection) => void;      // Callback for move action
   onDelete: (collection: Collection) => void;    // Callback for delete action
   onManageCollaborators: (collection: Collection) => void; // Callback for managing collaborators
+  onEditNotes?: (collection: Collection) => void; // Optional: edit Collection Notes (MANAGE only)
+  canManage?: boolean;                           // Controls visibility of MANAGE-only items
   triggerLabel?: string;
 }
 
@@ -27,6 +29,8 @@ const CollectionSettingsMenu: React.FC<CollectionSettingsMenuProps> = ({
   onMove,
   onDelete,
   onManageCollaborators,
+  onEditNotes,
+  canManage,
   triggerLabel,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -134,6 +138,36 @@ const CollectionSettingsMenu: React.FC<CollectionSettingsMenuProps> = ({
 
             Move Collection
           </button>
+          {canManage && onEditNotes && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onEditNotes(collection);
+                setIsOpen(false);
+              }}
+              className='text-text-normal'
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-start',
+                gap: '0.5rem',
+                width: '100%',
+                textAlign: 'left',
+                padding: '0.5rem 1rem',
+                border: 'none',
+                backgroundColor: 'transparent',
+                cursor: 'pointer',
+                borderRadius: '0.25rem',
+                textWrap: 'nowrap',
+              }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M4 4h12l4 4v12a0 0 0 0 1 0 0H4a0 0 0 0 1 0 0V4z" stroke="var(--color-contrast)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                <path d="M8 10h8M8 14h8M8 18h5" stroke="var(--color-contrast)" strokeWidth="1.5" strokeLinecap="round"/>
+              </svg>
+              Collection Notes
+            </button>
+          )}
           <button
             onClick={(e) => {
               e.stopPropagation();

--- a/react/src/features/collections/components/CollectionView.tsx
+++ b/react/src/features/collections/components/CollectionView.tsx
@@ -29,6 +29,7 @@ const CollectionView: React.FC<CollectionViewProps> = ({ collectionId, onBack })
     permission_level: string | null;
   } | null>(null);
   const [isUserManagementModalOpen, setIsUserManagementModalOpen] = useState(false);
+  const [canManage, setCanManage] = useState<boolean>(false);
 
   const fetchCollectionData = useCallback(() => {
     setLoading(true);
@@ -46,6 +47,7 @@ const CollectionView: React.FC<CollectionViewProps> = ({ collectionId, onBack })
       .then((data) => {
         if (!data.collection) throw new Error('Invalid response format');
         if (data.permission_source) setPermissionSource(data.permission_source);
+        setCanManage(Boolean(data.can_manage));
         setCollection({
           id: data.collection.id,
           name: data.collection.name,
@@ -226,6 +228,10 @@ const CollectionView: React.FC<CollectionViewProps> = ({ collectionId, onBack })
       successMessage={successMessage}
       isBatchOperationLoading={isBatchOperationLoading}
       isUserManagementModalOpen={isUserManagementModalOpen}
+      canManage={canManage}
+      onOpenCollectionNotes={() => {
+        window.location.href = `/aquillm/collections/${collection.id}/notes/`;
+      }}
       onBack={handleBack}
       onManageCollaborators={handleManageCollaborators}
       onDelete={handleDelete}

--- a/react/src/features/collections/components/CollectionViewShell.tsx
+++ b/react/src/features/collections/components/CollectionViewShell.tsx
@@ -28,6 +28,8 @@ export interface CollectionViewShellProps {
   successMessage: string | null;
   isBatchOperationLoading: boolean;
   isUserManagementModalOpen: boolean;
+  canManage: boolean;
+  onOpenCollectionNotes: () => void;
   onBack: () => void;
   onManageCollaborators: () => void;
   onDelete: () => void;
@@ -61,6 +63,8 @@ const CollectionViewShell: React.FC<CollectionViewShellProps> = ({
   successMessage,
   isBatchOperationLoading,
   isUserManagementModalOpen,
+  canManage,
+  onOpenCollectionNotes,
   onBack,
   onManageCollaborators,
   onDelete,
@@ -142,6 +146,8 @@ const CollectionViewShell: React.FC<CollectionViewShellProps> = ({
           onDelete={onDelete}
           triggerLabel="Collection Settings"
           onMove={onOpenCollectionSettingsMove}
+          onEditNotes={onOpenCollectionNotes}
+          canManage={canManage}
         />
       </div>
     </div>

--- a/react/src/features/skills/api/skillsApi.ts
+++ b/react/src/features/skills/api/skillsApi.ts
@@ -69,3 +69,34 @@ export async function deleteSkill(id: number): Promise<void> {
     throw new Error(`Delete failed (${r.status})`);
   }
 }
+
+export interface CollectionSkill {
+  collection_id: number;
+  collection_name: string;
+  body: string;
+  updated_at: string | null;
+  updated_by: string | null;
+  exists: boolean;
+  max_body_length: number;
+}
+
+export async function getCollectionSkill(collectionId: number): Promise<CollectionSkill> {
+  const r = await fetch(`/api/collections/${collectionId}/skill/`, { credentials: 'include' });
+  return jsonOrThrow<CollectionSkill>(r);
+}
+
+export async function saveCollectionSkill(
+  collectionId: number,
+  body: string,
+): Promise<CollectionSkill> {
+  const r = await fetch(`/api/collections/${collectionId}/skill/`, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': csrfToken(),
+    },
+    body: JSON.stringify({ body }),
+  });
+  return jsonOrThrow<CollectionSkill>(r);
+}

--- a/react/src/features/skills/components/CollectionNotesPage.tsx
+++ b/react/src/features/skills/components/CollectionNotesPage.tsx
@@ -1,0 +1,183 @@
+// Full-page editor for per-collection notes.
+//
+// Lives in the `collection_notes` bundle alongside Monaco — NOT in main.js.
+// See `vite.config.skills.ts` and `vite.config.ts` for why Monaco can't live
+// in the main app bundle.
+import React, { lazy, Suspense, useEffect, useState } from 'react';
+
+import {
+  getCollectionSkill,
+  saveCollectionSkill,
+  type CollectionSkill,
+} from '../api/skillsApi';
+
+const SkillEditor = lazy(() => import('./SkillEditor'));
+
+const SOFT_WARNING_RATIO = 0.75;
+
+export interface CollectionNotesPageProps {
+  collectionId: number;
+  collectionName: string;
+  collectionUrl: string;
+}
+
+const CollectionNotesPage: React.FC<CollectionNotesPageProps> = ({
+  collectionId,
+  collectionName,
+  collectionUrl,
+}) => {
+  const [data, setData] = useState<CollectionSkill | null>(null);
+  const [body, setBody] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(true);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dirty, setDirty] = useState<boolean>(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setDirty(false);
+    getCollectionSkill(collectionId)
+      .then((result) => {
+        if (cancelled) return;
+        setData(result);
+        setBody(result.body);
+      })
+      .catch((e: Error) => {
+        if (!cancelled) setError(e.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [collectionId]);
+
+  useEffect(() => {
+    const beforeUnload = (e: BeforeUnloadEvent) => {
+      if (dirty) {
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    };
+    window.addEventListener('beforeunload', beforeUnload);
+    return () => window.removeEventListener('beforeunload', beforeUnload);
+  }, [dirty]);
+
+  const handleSave = async () => {
+    if (!data) return;
+    if (body.length > data.max_body_length) {
+      setError(`Notes too long (max ${data.max_body_length} characters)`);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await saveCollectionSkill(collectionId, body);
+      setData(updated);
+      setBody(updated.body);
+      setDirty(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleChange = (next: string) => {
+    setBody(next);
+    setDirty(true);
+  };
+
+  const handleBack = () => {
+    if (dirty && !window.confirm('Discard unsaved changes?')) return;
+    window.location.href = collectionUrl;
+  };
+
+  const maxLen = data?.max_body_length ?? 16000;
+  const softLimit = Math.floor(maxLen * SOFT_WARNING_RATIO);
+  const overSoft = body.length > softLimit;
+  const overHard = body.length > maxLen;
+
+  return (
+    <div className="p-[24px] md:p-[32px] flex flex-col h-full">
+      <div className="mb-4">
+        <button
+          onClick={handleBack}
+          className="h-[36px] px-3 rounded-[18px] bg-scheme-shade_4 text-text-slightly_less_contrast border border-border-mid_contrast hover:bg-scheme-shade_5 hover:text-text-normal transition-colors cursor-pointer inline-flex items-center justify-center mb-[12px]"
+        >
+          {'← Back to collection'}
+        </button>
+        <h1 className="text-[2.05rem] font-semibold leading-none text-text-normal">
+          Collection Notes — {collectionName}
+        </h1>
+        <p className="text-sm text-text-slightly_less_contrast mt-2 max-w-3xl">
+          Markdown notes AquiLLM will keep in mind when answering questions about this
+          collection. Use this for author lists, terminology, tool versions, and other
+          domain knowledge you want the assistant to remember. The notes are appended to
+          the chat system prompt whenever this collection is selected in a conversation.
+        </p>
+      </div>
+
+      <div className="flex-1 min-h-0 border border-border-low_contrast rounded mb-3">
+        {loading ? (
+          <div className="h-full flex items-center justify-center text-text-slightly_less_contrast">
+            Loading…
+          </div>
+        ) : (
+          <Suspense
+            fallback={
+              <div className="h-full flex items-center justify-center text-text-slightly_less_contrast">
+                Loading editor…
+              </div>
+            }
+          >
+            <SkillEditor value={body} onChange={handleChange} />
+          </Suspense>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between border-t border-border-low_contrast pt-3">
+        <div className="text-sm">
+          <span
+            className={
+              overHard
+                ? 'text-red'
+                : overSoft
+                ? 'text-yellow-400'
+                : 'text-text-slightly_less_contrast'
+            }
+          >
+            {body.length.toLocaleString()} / {maxLen.toLocaleString()} characters
+          </span>
+          {error && <span className="ml-4 text-red">{error}</span>}
+          {data?.updated_at && !dirty && !error && (
+            <span className="ml-4 text-text-slightly_less_contrast">
+              Saved {new Date(data.updated_at).toLocaleString()}
+              {data.updated_by && ` by ${data.updated_by}`}
+            </span>
+          )}
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={handleBack}
+            className="px-4 py-2 rounded-md border border-border-mid_contrast text-text-normal hover:bg-scheme-shade_5"
+          >
+            Back
+          </button>
+          <button
+            onClick={() => void handleSave()}
+            disabled={saving || loading || overHard || !dirty}
+            className="px-4 py-2 rounded-md bg-accent text-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-accent-dark"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CollectionNotesPage;

--- a/react/vite.config.skills.ts
+++ b/react/vite.config.skills.ts
@@ -8,10 +8,15 @@ import react from '@vitejs/plugin-react'
 // because main.js is loaded with a classic `<script>` tag — see the comment
 // in `vite.config.ts`.
 //
+// The Collection Notes page (per-collection markdown notes for owners) shares
+// this bundle config because it has the same constraint: Monaco editor in a
+// React.lazy chunk, ES-module output. Both pages are loaded with
+// `<script type="module">` in their respective templates.
+//
 // Output:
-//   static/js/dist/skills.js                    (entry, ES module)
-//   static/js/dist/skills.css                   (entry CSS, if any)
-//   static/js/dist/chunks/SkillEditor-*.js      (Monaco lazy chunk)
+//   static/js/dist/skills.js                    (skills entry, ES module)
+//   static/js/dist/collection_notes.js          (collection notes entry, ES module)
+//   static/js/dist/chunks/SkillEditor-*.js      (Monaco lazy chunk, shared)
 //   static/js/dist/workers/editor.worker-*.js   (Monaco's web worker)
 export default defineConfig({
   plugins: [react()],
@@ -25,6 +30,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         skills: './src/skills_entry.tsx',
+        collection_notes: './src/collection_notes_entry.tsx',
       },
       output: {
         entryFileNames: '[name].js',


### PR DESCRIPTION
Summary

Each collection now has its own markdown notes file, edited by owners via Monaco at /aquillm/collections/<id>/notes/.
The notes are appended to AquiLLM's instructions whenever the collection is selected in a chat, and only then.
Also strengthens the default chat system prompt to require vector_search, fixing an incidental hallucination issue that surfaced during testing with GPT 4o. That aspect can be removed if needed. 

Closes #215
