### PR TITLE
fix of where and summarize function in Advanced Query Builder; fixed bidirectionality issues

### DIFF
--- a/react/src/features/platform_admin/components/feedback-dashboard/FeedbackDashboard.tsx
+++ b/react/src/features/platform_admin/components/feedback-dashboard/FeedbackDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import FilterBar from './FilterBar';
 import { QueryBuilderAdvanced } from './QueryBuilder';
 import QueryBuilderHelp from './QueryBuilderHelp';
@@ -6,9 +6,11 @@ import ResultsChart from './ResultsChart';
 import ResultsTable from './ResultsTable';
 import ThreadModal from './ThreadModal';
 import { b64decode, b64encode, runQuery } from './api';
-import { useFilterBar } from './useFilterBar';
+import { useFilterBar, buildBasicClauses, EMPTY_FILTER_STATE } from './useFilterBar';
+import { useAdvancedBuilder, buildAdvancedClauses } from './useAdvancedBuilder';
 import { useFilterOptions } from './useFilterOptions';
 import type { FilterState } from './useFilterBar';
+import type { ParsedAdvanced } from './useAdvancedBuilder';
 import type { QueryResponse } from './types';
 
 // ---------------------------------------------------------------------------
@@ -18,17 +20,15 @@ import type { QueryResponse } from './types';
 function isPageReload(): boolean {
   try {
     const entries = window.performance?.getEntriesByType('navigation') ?? [];
-    if (entries.length > 0) {
+    if (entries.length > 0)
       return (entries[0] as PerformanceNavigationTiming).type === 'reload';
-    }
   } catch { /* ignore */ }
   return false;
 }
 
 function readQueryFromUrl(): string {
   if (isPageReload()) {
-    if (window.location.search)
-      window.history.replaceState({}, '', window.location.pathname);
+    if (window.location.search) window.history.replaceState({}, '', window.location.pathname);
     return '';
   }
   const params = new URLSearchParams(window.location.search);
@@ -36,89 +36,209 @@ function readQueryFromUrl(): string {
   return q ? b64decode(q) : '';
 }
 
-function buildShareableUrl(queryText: string): string {
-  const encoded = b64encode(queryText);
-  return `${window.location.origin}${window.location.pathname}?q=${encodeURIComponent(encoded)}`;
+function buildShareableUrl(text: string): string {
+  return `${window.location.origin}${window.location.pathname}?q=${encodeURIComponent(b64encode(text))}`;
 }
 
-function extractBadToken(errorMessage: string): string | null {
-  const match = errorMessage.match(/'([^']+)'|"([^"]+)"/);
-  if (!match) return null;
-  return match[1] ?? match[2] ?? null;
+function extractBadToken(msg: string): string | null {
+  const m = msg.match(/'([^']+)'|"([^"]+)"/);
+  return m ? (m[1] ?? m[2] ?? null) : null;
+}
+
+// Build the full combined KQL from Basic filters + Advanced clause list.
+// Basic where clauses come first; Advanced appends after.
+function buildCombinedKQL(basicClauses: string[], advancedClauses: string[]): string {
+  const all = [...basicClauses, ...advancedClauses];
+  if (all.length === 0) return 'messages';
+  return `messages\n${all.map(c => `| ${c}`).join('\n')}`;
 }
 
 // ---------------------------------------------------------------------------
-// Parse a KQL string back into FilterState fields.
-// Only recognises clauses that buildKQLFromFilters produces — anything else
-// (e.g. custom where clauses) is silently ignored. Missing clauses leave the
-// corresponding field at its EMPTY_FILTER_STATE default.
+// Full KQL parser — splits each clause between Basic and Advanced.
+//
+// Basic patterns: the exact operators that FilterBar dropdowns can represent.
+// Everything else (different operators, summarize, select, order by, limit)
+// goes into Advanced rows.
 // ---------------------------------------------------------------------------
-function parseKQLToFilters(kql: string): Partial<FilterState> {
-  const result: Partial<FilterState> = {};
-  // Split on pipe separators handling both inline (|) and multi-line (newline | )
+function parseKQLFull(kql: string): { filters: Partial<FilterState>; advanced: ParsedAdvanced } {
+  const filters: Partial<FilterState> = {};
+  const advanced: ParsedAdvanced = {
+    whereRows: [],
+    summarizeRows: [],
+    selectFields: [],
+    orderByRows: [],
+    limitValue: null,
+  };
+
   const clauses = kql
     .split(/\n?\s*\|\s*/)
-    .map((s) => s.trim())
+    .map(s => s.trim())
     .filter(Boolean);
 
   for (const clause of clauses) {
-    let m: RegExpMatchArray | null;
+    // Skip the stream identifier
+    if (clause === 'messages' || clause.startsWith('messages ')) continue;
 
-    // date range
-    m = clause.match(/^where feedback_submitted_at >= "(\d{4}-\d{2}-\d{2})"/);
-    if (m) { result.date_from = m[1]; continue; }
-
-    m = clause.match(/^where feedback_submitted_at <= "(\d{4}-\d{2}-\d{2})"/);
-    if (m) { result.date_to = m[1]; continue; }
-
-    // user_id
-    m = clause.match(/^where user_id == (\d+)/);
-    if (m) { result.user_id = m[1]; continue; }
-
-    // rating (exact before range so exact_rating wins)
-    m = clause.match(/^where rating == (\d+)/);
-    if (m) { result.exact_rating = m[1]; continue; }
-
-    m = clause.match(/^where rating >= (\d+)/);
-    if (m) { result.min_rating = m[1]; continue; }
-
-    m = clause.match(/^where rating <= (\d+)/);
-    if (m) { result.max_rating = m[1]; continue; }
-
-    // role
-    m = clause.match(/^where role == "([^"\\]*)"/);
-    if (m) { result.role = m[1]; continue; }
-
-    // model
-    m = clause.match(/^where model == "([^"\\]*)"/);
-    if (m) { result.model = m[1]; continue; }
-
-    // tool_call_name
-    m = clause.match(/^where tool_call_name == "([^"\\]*)"/);
-    if (m) { result.tool_call_name = m[1]; continue; }
-
-    // has_feedback_text
-    if (/^where feedback_text != null/.test(clause)) {
-      result.has_feedback_text = 'true'; continue;
-    }
-    if (/^where feedback_text == null/.test(clause)) {
-      result.has_feedback_text = 'false'; continue;
+    // ── summarize ──────────────────────────────────────────────────────
+    {
+      const m = clause.match(/^summarize (\w+)\s*=\s*(\w+)\(([^)]*)\)(?:\s+by\s+(\S+))?/);
+      if (m) {
+        advanced.summarizeRows.push({
+          alias: m[1],
+          func: m[2],
+          field: m[3]?.trim() ?? '',
+          byField: m[4]?.trim() ?? '',
+        });
+        continue;
+      }
     }
 
-    // feedback_text_search (must come after the null checks above)
-    m = clause.match(/^where feedback_text contains "([^"\\]*)"/);
-    if (m) { result.feedback_text_search = m[1]; continue; }
+    // ── select ─────────────────────────────────────────────────────────
+    {
+      const m = clause.match(/^select (.+)/);
+      if (m) {
+        advanced.selectFields = m[1].split(',').map(f => f.trim()).filter(Boolean);
+        continue;
+      }
+    }
 
-    // limit
-    m = clause.match(/^limit (\d+)/);
-    if (m) { result.limit = parseInt(m[1], 10); continue; }
+    // ── order by ───────────────────────────────────────────────────────
+    {
+      const m = clause.match(/^order by (\S+)(?:\s+(asc|desc))?/i);
+      if (m) {
+        advanced.orderByRows.push({
+          field: m[1],
+          dir: (m[2]?.toLowerCase() ?? 'desc') as 'asc' | 'desc',
+        });
+        continue;
+      }
+    }
+
+    // ── limit ──────────────────────────────────────────────────────────
+    {
+      const m = clause.match(/^limit (\d+)/);
+      if (m) { advanced.limitValue = parseInt(m[1], 10); continue; }
+    }
+
+    // ── where — try Basic patterns first, fall through to Advanced ──────
+    if (clause.startsWith('where ')) {
+      let matched = false;
+
+      // date range (Basic only handles >= / <=)
+      let m = clause.match(/^where feedback_submitted_at >= "(\d{4}-\d{2}-\d{2})"/);
+      if (m) { filters.date_from = m[1]; matched = true; }
+
+      if (!matched) {
+        m = clause.match(/^where feedback_submitted_at <= "(\d{4}-\d{2}-\d{2})"/);
+        if (m) { filters.date_to = m[1]; matched = true; }
+      }
+
+      // user_id (Basic only handles ==)
+      if (!matched) {
+        m = clause.match(/^where user_id == (\d+)/);
+        if (m) { filters.user_id = m[1]; matched = true; }
+      }
+
+      // rating == (Basic exact_rating)
+      if (!matched) {
+        m = clause.match(/^where rating == (\d+)/);
+        if (m) { filters.exact_rating = m[1]; matched = true; }
+      }
+
+      // rating >= (Basic min_rating)
+      if (!matched) {
+        m = clause.match(/^where rating >= (\d+)/);
+        if (m) { filters.min_rating = m[1]; matched = true; }
+      }
+
+      // rating <= (Basic max_rating)
+      if (!matched) {
+        m = clause.match(/^where rating <= (\d+)/);
+        if (m) { filters.max_rating = m[1]; matched = true; }
+      }
+
+      // role == (Basic)
+      if (!matched) {
+        m = clause.match(/^where role == "([^"\\]*)"/);
+        if (m) { filters.role = m[1]; matched = true; }
+      }
+
+      // model == (Basic)
+      if (!matched) {
+        m = clause.match(/^where model == "([^"\\]*)"/);
+        if (m) { filters.model = m[1]; matched = true; }
+      }
+
+      // tool_call_name == (Basic)
+      if (!matched) {
+        m = clause.match(/^where tool_call_name == "([^"\\]*)"/);
+        if (m) { filters.tool_call_name = m[1]; matched = true; }
+      }
+
+      // feedback_text != null (Basic has_feedback_text)
+      if (!matched && /^where feedback_text != null/.test(clause)) {
+        filters.has_feedback_text = 'true'; matched = true;
+      }
+
+      // feedback_text == null (Basic has_feedback_text)
+      if (!matched && /^where feedback_text == null/.test(clause)) {
+        filters.has_feedback_text = 'false'; matched = true;
+      }
+
+      // feedback_text contains (Basic text search)
+      if (!matched) {
+        m = clause.match(/^where feedback_text contains "([^"\\]*)"/);
+        if (m) { filters.feedback_text_search = m[1]; matched = true; }
+      }
+
+      if (!matched) {
+        // Doesn't match any Basic pattern → Advanced where row
+        const rest = clause.slice('where '.length).trim();
+
+        // Parse: field op value
+        // Try null operators first
+        const nullM = rest.match(/^(\S+)\s+(==|!=) null$/);
+        if (nullM) {
+          advanced.whereRows.push({ field: nullM[1], op: `${nullM[2]} null`, value: '' });
+          continue;
+        }
+
+        // contains / startswith
+        const strOpM = rest.match(/^(\S+)\s+(contains|startswith) "([^"]*)"/);
+        if (strOpM) {
+          advanced.whereRows.push({ field: strOpM[1], op: strOpM[2], value: strOpM[3] });
+          continue;
+        }
+
+        // in [...]
+        const inM = rest.match(/^(\S+)\s+in \[([^\]]*)\]/);
+        if (inM) {
+          advanced.whereRows.push({ field: inM[1], op: 'in', value: inM[2] });
+          continue;
+        }
+
+        // comparison operators
+        const compM = rest.match(/^(\S+)\s+(==|!=|>=|<=|>|<)\s+(.+)/);
+        if (compM) {
+          const rawVal = compM[3].trim();
+          // Strip surrounding quotes if present
+          const val = rawVal.startsWith('"') && rawVal.endsWith('"')
+            ? rawVal.slice(1, -1)
+            : rawVal;
+          advanced.whereRows.push({ field: compM[1], op: compM[2], value: val });
+          continue;
+        }
+
+        // Unrecognised — skip
+      }
+    }
   }
 
-  return result;
+  return { filters, advanced };
 }
 
 // ---------------------------------------------------------------------------
-// DashboardSection — collapsible panel with a Run button in the header
+// DashboardSection
 // ---------------------------------------------------------------------------
 
 type SectionProps = {
@@ -130,25 +250,20 @@ type SectionProps = {
 };
 
 const DashboardSection: React.FC<SectionProps> = ({
-  title,
-  defaultOpen = false,
-  onRun,
-  extraActions,
-  children,
+  title, defaultOpen = false, onRun, extraActions, children,
 }) => {
   const [open, setOpen] = useState(defaultOpen);
-
   return (
     <div className="mb-5 rounded-lg bg-scheme-shade_3 element-border text-sm overflow-hidden">
       <div
         className="flex items-center justify-between px-4 py-2.5 cursor-pointer select-none hover:bg-scheme-shade_5/40 transition-colors"
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => setOpen(o => !o)}
       >
         <span className="flex items-center gap-2 font-semibold text-text-normal">
           <span className="font-mono text-text-muted text-xs">{open ? '▼' : '▶'}</span>
           {title}
         </span>
-        <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center gap-2" onClick={e => e.stopPropagation()}>
           {extraActions}
           <button
             onClick={onRun}
@@ -172,24 +287,53 @@ const FeedbackDashboard: React.FC = () => {
   const [response, setResponse] = useState<QueryResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [thread, setThread] = useState<{ conversationId: string; messageUuid: string } | null>(null);
-  const [showHelp, setShowHelp] = useState<boolean>(false);
+  const [showHelp, setShowHelp] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  const {
-    filters,
-    kqlForExecution,
-    hasActiveFilters,
-    setFilter,
-    setAllFilters,
-    resetFilters,
-  } = useFilterBar();
-
+  const { filters, basicKQL, hasActiveFilters, setFilter, setAllFilters, resetFilters } =
+    useFilterBar();
+  const adv = useAdvancedBuilder();
   const { options, loading: optionsLoading } = useFilterOptions();
 
-  // When true, the kqlForExecution effect should NOT overwrite queryText because
-  // the filter change was itself triggered by a textarea edit.
-  const filtersDrivenByTextarea = useRef(false);
+  // ── Combined KQL (derived) ────────────────────────────────────────────
+  // basicKQL already encodes the debounced basic where clauses.
+  // We extract just the clause strings (everything after "messages\n| ").
+  const basicClauseStrings = useMemo(() => {
+    if (basicKQL === 'messages') return [];
+    return basicKQL
+      .split(/\n?\s*\|\s*/)
+      .map(s => s.trim())
+      .filter(s => s && s !== 'messages');
+  }, [basicKQL]);
 
+  const advancedClauseStrings = useMemo(
+    () => buildAdvancedClauses(adv.state),
+    [adv.state],
+  );
+
+  const combinedKQL = useMemo(
+    () => buildCombinedKQL(basicClauseStrings, advancedClauseStrings),
+    [basicClauseStrings, advancedClauseStrings],
+  );
+
+  // ── Sync control ──────────────────────────────────────────────────────
+  // true  → state changed via UI; combinedKQL effect should update textarea + run
+  // false → textarea changed state; combinedKQL effect should be suppressed
+  const stateChangedByUI = useRef(false);
+  const isFirstRender = useRef(true);
+
+  // ── Auto-run when combined KQL changes due to UI interaction ──────────
+  useEffect(() => {
+    if (isFirstRender.current) { isFirstRender.current = false; return; }
+    if (!stateChangedByUI.current) return;
+    stateChangedByUI.current = false;
+    setQueryText(combinedKQL);
+    window.history.replaceState({}, '', window.location.pathname);
+    void executeQuery(combinedKQL);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [combinedKQL]);
+
+  // ── Execution ─────────────────────────────────────────────────────────
   const executeQuery = async (text: string) => {
     const trimmed = text.trim();
     if (!trimmed) return;
@@ -201,11 +345,7 @@ const FeedbackDashboard: React.FC = () => {
     } catch (err) {
       setResponse({
         query_text: trimmed,
-        rows: [],
-        columns: [],
-        is_row_level: true,
-        chart_data: null,
-        row_count: 0,
+        rows: [], columns: [], is_row_level: true, chart_data: null, row_count: 0,
         error: err instanceof Error ? err.message : 'Unknown error',
       });
     } finally {
@@ -213,102 +353,78 @@ const FeedbackDashboard: React.FC = () => {
     }
   };
 
-  // -------------------------------------------------------------------------
-  // Filter bar auto-execution (debounced via useFilterBar)
-  // When kqlForExecution changes and it was driven by the FilterBar (not by a
-  // textarea edit), update the textarea and run the query automatically.
-  // -------------------------------------------------------------------------
-  const isFirstRender = useRef(true);
-
-  useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
-    }
-    if (filtersDrivenByTextarea.current) {
-      // This kqlForExecution update came from parsing the textarea — don't
-      // overwrite what the user typed, and don't auto-run.
-      filtersDrivenByTextarea.current = false;
-      return;
-    }
-    // FilterBar drove this change — update textarea to show generated KQL
-    setQueryText(kqlForExecution);
-    window.history.replaceState({}, '', window.location.pathname);
-    void executeQuery(kqlForExecution.trim());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [kqlForExecution]);
-
-  // -------------------------------------------------------------------------
-  // Initial load from URL ?q=
-  // -------------------------------------------------------------------------
+  // ── Initial URL load ──────────────────────────────────────────────────
   useEffect(() => {
     if (queryText.trim()) {
+      const { filters: f, advanced: a } = parseKQLFull(queryText);
+      setAllFilters(f);
+      adv.setFromParsed(a);
       void executeQuery(queryText);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // -------------------------------------------------------------------------
-  // Browser back/forward
-  // -------------------------------------------------------------------------
+  // ── Back/forward ──────────────────────────────────────────────────────
   useEffect(() => {
     const onPopState = () => {
       const next = readQueryFromUrl();
       setQueryText(next);
-      if (next.trim()) void executeQuery(next);
-      else setResponse(null);
+      if (next.trim()) {
+        const { filters: f, advanced: a } = parseKQLFull(next);
+        setAllFilters(f);
+        adv.setFromParsed(a);
+        void executeQuery(next);
+      } else {
+        setResponse(null);
+      }
     };
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // -------------------------------------------------------------------------
-  // Shared Run handler (used by all three section Run buttons)
-  // Parses the current textarea KQL back into filters so all sections stay
-  // in sync after a manual edit.
-  // -------------------------------------------------------------------------
+  // ── Shared Run ────────────────────────────────────────────────────────
   const handleRun = () => {
     const trimmed = queryText.trim();
     if (!trimmed) return;
-    // Sync textarea → filters without triggering auto-execution loop
-    filtersDrivenByTextarea.current = true;
-    setAllFilters(parseKQLToFilters(queryText));
-    // Execute
+    // Sync textarea → state (don't trigger auto-run loop)
+    stateChangedByUI.current = false;
+    const { filters: f, advanced: a } = parseKQLFull(trimmed);
+    setAllFilters(f);
+    adv.setFromParsed(a);
+    // Execute with what the user sees
     window.history.pushState({}, '', buildShareableUrl(trimmed));
     void executeQuery(trimmed);
   };
 
-  // -------------------------------------------------------------------------
-  // Textarea change — update filters live so the Basic Query Builder reflects
-  // what is typed.
-  // -------------------------------------------------------------------------
+  // ── Textarea change → sync both Basic and Advanced ────────────────────
   const handleQueryChange = (v: string) => {
     setQueryText(v);
-    // Mark that the coming kqlForExecution update is caused by us, not FilterBar
-    filtersDrivenByTextarea.current = true;
-    setAllFilters(parseKQLToFilters(v));
+    stateChangedByUI.current = false; // suppress combinedKQL auto-run
+    const { filters: f, advanced: a } = parseKQLFull(v);
+    setAllFilters(f);
+    adv.setFromParsed(a);
   };
 
-  // -------------------------------------------------------------------------
-  // FilterBar control change — clear the textarea-source flag so the next
-  // kqlForExecution update correctly overwrites the textarea.
-  // -------------------------------------------------------------------------
-  const handleFilterChange = (key: keyof FilterState, value: string | number) => {
-    filtersDrivenByTextarea.current = false;
-    setFilter(key, value as string);
+  // ── Basic filter control change ───────────────────────────────────────
+  const handleFilterChange = (key: keyof FilterState, value: string) => {
+    stateChangedByUI.current = true;
+    setFilter(key, value);
   };
 
   const handleReset = () => {
-    filtersDrivenByTextarea.current = false;
+    stateChangedByUI.current = true;
     resetFilters();
+    adv.reset();
     setQueryText('');
     setResponse(null);
     window.history.pushState({}, '', window.location.pathname);
   };
 
   const handleClear = () => {
-    filtersDrivenByTextarea.current = false;
+    stateChangedByUI.current = false;
     resetFilters();
+    adv.reset();
     setQueryText('');
     setResponse(null);
     window.history.pushState({}, '', window.location.pathname);
@@ -322,40 +438,38 @@ const FeedbackDashboard: React.FC = () => {
     setTimeout(() => setCopied(false), 2000);
   };
 
-  // Advanced Query Builder appends clauses — also clear the textarea-source flag
-  const handleAdvancedChange = (v: string) => {
-    filtersDrivenByTextarea.current = false;
-    setQueryText(v);
-    // Parse back to update Basic filters too
-    filtersDrivenByTextarea.current = true;
-    setAllFilters(parseKQLToFilters(v));
-  };
+  // ── Advanced builder actions (each sets stateChangedByUI = true) ──────
+  const advAction = <T extends unknown[]>(fn: (...args: T) => void) =>
+    (...args: T) => { stateChangedByUI.current = true; fn(...args); };
 
   const hasQueryRun = response !== null;
   const badToken = response?.error ? extractBadToken(response.error) : null;
 
   return (
     <div className="container mx-auto p-6 text-text-normal max-w-7xl">
-      {/* Page header */}
       <div className="flex items-center gap-3 mb-6">
         <h1 className="text-2xl font-bold">Feedback Dashboard</h1>
         <button
           onClick={() => setShowHelp(true)}
           className="w-6 h-6 rounded-full bg-scheme-shade_5 hover:bg-scheme-shade_6 text-text-muted hover:text-text-normal text-xs font-bold flex items-center justify-center transition-colors"
           title="How the query language works"
-        >
-          ?
-        </button>
+        >?</button>
       </div>
 
       {showHelp && <QueryBuilderHelp onClose={() => setShowHelp(false)} />}
 
-      {/* ----------------------------------------------------------------- */}
-      {/* Section 1: Basic Query Builder (FilterBar dropdowns)               */}
-      {/* ----------------------------------------------------------------- */}
-      <DashboardSection title="Basic Query Builder" defaultOpen={true} onRun={handleRun}>
-        {/* Render FilterBar content without its built-in outer wrapper so
-            the DashboardSection header is the only header shown */}
+      {/* Section 1: Basic Query Builder */}
+      <DashboardSection
+        title="Basic Query Builder"
+        defaultOpen={true}
+        onRun={handleRun}
+        extraActions={
+          <button
+            onClick={handleClear}
+            className="px-3 py-1 rounded bg-scheme-shade_5 hover:bg-scheme-shade_6 text-xs transition-all"
+          >Clear</button>
+        }
+      >
         <FilterBar
           filters={filters}
           options={options}
@@ -367,16 +481,32 @@ const FeedbackDashboard: React.FC = () => {
         />
       </DashboardSection>
 
-      {/* ----------------------------------------------------------------- */}
-      {/* Section 2: Advanced Query Builder (visual clause builder)          */}
-      {/* ----------------------------------------------------------------- */}
-      <DashboardSection title="Advanced Query Builder" onRun={handleRun}>
-        <QueryBuilderAdvanced value={queryText} onChange={handleAdvancedChange} />
+      {/* Section 2: Advanced Query Builder */}
+      <DashboardSection
+        title="Advanced Query Builder"
+        onRun={handleRun}
+        extraActions={
+          <button
+            onClick={handleClear}
+            className="px-3 py-1 rounded bg-scheme-shade_5 hover:bg-scheme-shade_6 text-xs transition-all"
+          >Clear</button>
+        }
+      >
+        <QueryBuilderAdvanced
+          state={adv.state}
+          onAddWhere={advAction(adv.addWhere)}
+          onRemoveWhere={advAction(adv.removeWhere)}
+          onAddSummarize={advAction(adv.addSummarize)}
+          onRemoveSummarize={advAction(adv.removeSummarize)}
+          onToggleSelect={advAction(adv.toggleSelect)}
+          onRemoveSelect={advAction(adv.removeSelect)}
+          onAddOrderBy={advAction(adv.addOrderBy)}
+          onRemoveOrderBy={advAction(adv.removeOrderBy)}
+          onSetLimit={advAction(adv.setLimitValue)}
+        />
       </DashboardSection>
 
-      {/* ----------------------------------------------------------------- */}
-      {/* Section 3: Textual Query — editable KQL textarea                   */}
-      {/* ----------------------------------------------------------------- */}
+      {/* Section 3: Textual Query */}
       <DashboardSection
         title="Textual Query"
         defaultOpen={true}
@@ -386,15 +516,11 @@ const FeedbackDashboard: React.FC = () => {
             <button
               onClick={handleCopyLink}
               className="px-3 py-1 rounded bg-scheme-shade_5 hover:bg-scheme-shade_6 text-xs transition-all"
-            >
-              {copied ? 'Copied!' : 'Copy link'}
-            </button>
+            >{copied ? 'Copied!' : 'Copy link'}</button>
             <button
               onClick={handleClear}
               className="px-3 py-1 rounded bg-scheme-shade_5 hover:bg-scheme-shade_6 text-xs transition-all"
-            >
-              Clear
-            </button>
+            >Clear</button>
           </>
         }
       >
@@ -405,8 +531,8 @@ const FeedbackDashboard: React.FC = () => {
             placeholder="messages | where rating < 3 | limit 20"
             className="w-full font-mono text-sm rounded-lg px-4 py-3 bg-scheme-shade_2 element-border text-text-normal placeholder-text-muted resize-y focus:outline-none focus:ring-2 focus:ring-blue-500/50"
             value={queryText}
-            onChange={(e) => handleQueryChange(e.target.value)}
-            onKeyDown={(e) => {
+            onChange={e => handleQueryChange(e.target.value)}
+            onKeyDown={e => {
               if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
                 e.preventDefault();
                 handleRun();
@@ -416,8 +542,8 @@ const FeedbackDashboard: React.FC = () => {
           <p className="text-xs text-text-muted mt-1.5">
             <span className="font-mono">Ctrl+Enter</span> /{' '}
             <span className="font-mono">⌘+Enter</span> to run.
-            Editing here updates the Basic Query Builder filters automatically.
-            Clauses added above appear here instantly.
+            Editing here updates both builders automatically.
+            Clauses added in either builder appear here instantly.
           </p>
         </div>
       </DashboardSection>
@@ -449,13 +575,9 @@ const FeedbackDashboard: React.FC = () => {
       {hasQueryRun && !response?.error && (
         <>
           <div className="mb-3 flex items-center gap-3 text-xs text-text-muted">
-            <span>
-              {response!.row_count} row{response!.row_count !== 1 ? 's' : ''}
-            </span>
+            <span>{response!.row_count} row{response!.row_count !== 1 ? 's' : ''}</span>
             {response!.query_text && (
-              <span className="font-mono truncate max-w-xl opacity-60">
-                {response!.query_text}
-              </span>
+              <span className="font-mono truncate max-w-xl opacity-60">{response!.query_text}</span>
             )}
           </div>
           {response!.chart_data && <ResultsChart data={response!.chart_data} />}
@@ -484,25 +606,24 @@ const FeedbackDashboard: React.FC = () => {
             <div>
               <p className="font-mono font-bold text-text-normal mb-2">messages stream</p>
               {[
-                ['rating', 'NUMBER', '1–5 star rating'],
-                ['feedback_text', 'TEXT', 'Written comment'],
-                ['feedback_submitted_at', 'TIME', 'When rating was submitted'],
-                ['model', 'TEXT', 'AI model used'],
-                ['role', 'TEXT', 'user / assistant / tool'],
-                ['content', 'TEXT', 'Message text'],
-                ['user_id', 'NUMBER', 'User account ID'],
-                ['conversation_id', 'NUMBER', 'Conversation ID'],
-                ['tool_call_name', 'TEXT', 'Tool used (intermediate only)'],
-                ['conversation_tool', 'ARRAY', 'Tools used in this conversation'],
-              ].map(([f, t, d]) => (
+                ['rating','NUMBER','1–5 star rating'],
+                ['feedback_text','TEXT','Written comment'],
+                ['feedback_submitted_at','TIME','When rating was submitted'],
+                ['model','TEXT','AI model used'],
+                ['role','TEXT','user / assistant / tool'],
+                ['content','TEXT','Message text'],
+                ['user_id','NUMBER','User account ID'],
+                ['conversation_id','NUMBER','Conversation ID'],
+                ['tool_call_name','TEXT','Tool used (intermediate only)'],
+                ['conversation_tool','ARRAY','Tools used in this conversation'],
+              ].map(([f,t,d]) => (
                 <div key={f} className="flex items-baseline gap-2 py-0.5 border-b border-scheme-contrast/10 last:border-0">
                   <span className="font-mono text-text-normal w-44 shrink-0">{f}</span>
                   <span className={`text-[10px] px-1 rounded shrink-0 ${
-                    t === 'NUMBER' ? 'bg-blue-600/30 text-blue-300' :
-                    t === 'TIME' ? 'bg-yellow-600/30 text-yellow-300' :
-                    t === 'ARRAY' ? 'bg-purple-600/30 text-purple-300' :
-                    'bg-green-600/30 text-green-300'
-                  }`}>{t}</span>
+                    t==='NUMBER'?'bg-blue-600/30 text-blue-300':
+                    t==='TIME'?'bg-yellow-600/30 text-yellow-300':
+                    t==='ARRAY'?'bg-purple-600/30 text-purple-300':
+                    'bg-green-600/30 text-green-300'}`}>{t}</span>
                   <span>{d}</span>
                 </div>
               ))}
@@ -510,26 +631,25 @@ const FeedbackDashboard: React.FC = () => {
             <div>
               <p className="font-mono font-bold text-text-normal mb-2">conversations stream</p>
               {[
-                ['conversation_id', 'NUMBER', 'Conversation ID'],
-                ['user_id', 'NUMBER', 'Owner user ID'],
-                ['name', 'TEXT', 'Auto-generated title'],
-                ['created_at', 'TIME', 'When conversation started'],
-                ['message_count', 'NUMBER', 'Total message turns'],
-                ['rated_count', 'NUMBER', 'Number of rated messages'],
-                ['avg_rating', 'NUMBER', 'Mean rating across messages'],
-                ['min_rating', 'NUMBER', 'Lowest rating in conv.'],
-                ['max_rating', 'NUMBER', 'Highest rating in conv.'],
-                ['last_rated_at', 'TIME', 'Most recent rating time'],
-                ['tools_used', 'ARRAY', 'Comma-list of distinct tools'],
-              ].map(([f, t, d]) => (
+                ['conversation_id','NUMBER','Conversation ID'],
+                ['user_id','NUMBER','Owner user ID'],
+                ['name','TEXT','Auto-generated title'],
+                ['created_at','TIME','When conversation started'],
+                ['message_count','NUMBER','Total message turns'],
+                ['rated_count','NUMBER','Number of rated messages'],
+                ['avg_rating','NUMBER','Mean rating across messages'],
+                ['min_rating','NUMBER','Lowest rating in conv.'],
+                ['max_rating','NUMBER','Highest rating in conv.'],
+                ['last_rated_at','TIME','Most recent rating time'],
+                ['tools_used','ARRAY','Comma-list of distinct tools'],
+              ].map(([f,t,d]) => (
                 <div key={f} className="flex items-baseline gap-2 py-0.5 border-b border-scheme-contrast/10 last:border-0">
                   <span className="font-mono text-text-normal w-36 shrink-0">{f}</span>
                   <span className={`text-[10px] px-1 rounded shrink-0 ${
-                    t === 'NUMBER' ? 'bg-blue-600/30 text-blue-300' :
-                    t === 'TIME' ? 'bg-yellow-600/30 text-yellow-300' :
-                    t === 'ARRAY' ? 'bg-purple-600/30 text-purple-300' :
-                    'bg-green-600/30 text-green-300'
-                  }`}>{t}</span>
+                    t==='NUMBER'?'bg-blue-600/30 text-blue-300':
+                    t==='TIME'?'bg-yellow-600/30 text-yellow-300':
+                    t==='ARRAY'?'bg-purple-600/30 text-purple-300':
+                    'bg-green-600/30 text-green-300'}`}>{t}</span>
                   <span>{d}</span>
                 </div>
               ))}
@@ -538,13 +658,13 @@ const FeedbackDashboard: React.FC = () => {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <p className="font-semibold text-text-normal mb-1">Operators</p>
-              {['== / !=  equal / not equal', '< > <= >=  numeric', 'contains "x"  substring', 'startswith "x"  prefix', 'in [1,2,3]  membership', '== null / != null  missing/present'].map(o => (
+              {['== / !=  equal / not equal','< > <= >=  numeric','contains "x"  substring','startswith "x"  prefix','in [1,2,3]  membership','== null / != null  missing/present'].map(o => (
                 <div key={o} className="font-mono text-text-normal/80 py-0.5 text-[11px]">{o}</div>
               ))}
             </div>
             <div>
               <p className="font-semibold text-text-normal mb-1">Aggregation functions</p>
-              {['avg(field)', 'count()', 'min(field)', 'max(field)', 'sum(field)', 'median(field)'].map(f => (
+              {['avg(field)','count()','min(field)','max(field)','sum(field)','median(field)'].map(f => (
                 <div key={f} className="font-mono text-text-normal/80 py-0.5 text-[11px]">{f}</div>
               ))}
             </div>

--- a/react/src/features/platform_admin/components/feedback-dashboard/FeedbackDashboard.tsx
+++ b/react/src/features/platform_admin/components/feedback-dashboard/FeedbackDashboard.tsx
@@ -599,76 +599,217 @@ const FeedbackDashboard: React.FC = () => {
       {/* Syntax quick reference */}
       <details className="mt-6 rounded-lg bg-scheme-shade_3 element-border text-sm">
         <summary className="px-4 py-2.5 cursor-pointer font-semibold select-none hover:text-blue-500 transition-colors">
-          Syntax quick reference
+          Syntax quick reference &amp; examples
         </summary>
-        <div className="px-5 py-4 text-xs space-y-4 text-text-muted">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <p className="font-mono font-bold text-text-normal mb-2">messages stream</p>
-              {[
-                ['rating','NUMBER','1–5 star rating'],
-                ['feedback_text','TEXT','Written comment'],
-                ['feedback_submitted_at','TIME','When rating was submitted'],
-                ['model','TEXT','AI model used'],
-                ['role','TEXT','user / assistant / tool'],
-                ['content','TEXT','Message text'],
-                ['user_id','NUMBER','User account ID'],
-                ['conversation_id','NUMBER','Conversation ID'],
-                ['tool_call_name','TEXT','Tool used (intermediate only)'],
-                ['conversation_tool','ARRAY','Tools used in this conversation'],
-              ].map(([f,t,d]) => (
-                <div key={f} className="flex items-baseline gap-2 py-0.5 border-b border-scheme-contrast/10 last:border-0">
-                  <span className="font-mono text-text-normal w-44 shrink-0">{f}</span>
-                  <span className={`text-[10px] px-1 rounded shrink-0 ${
-                    t==='NUMBER'?'bg-blue-600/30 text-blue-300':
-                    t==='TIME'?'bg-yellow-600/30 text-yellow-300':
-                    t==='ARRAY'?'bg-purple-600/30 text-purple-300':
-                    'bg-green-600/30 text-green-300'}`}>{t}</span>
-                  <span>{d}</span>
-                </div>
-              ))}
+        <div className="px-5 py-5 text-xs space-y-6 text-text-muted">
+
+          {/* ── How it works ── */}
+          <div>
+            <p className="font-semibold text-text-normal text-sm mb-2">How queries work</p>
+            <p className="leading-relaxed mb-2">
+              Every query is a <strong className="text-text-normal">pipeline</strong>. You start
+              with a <span className="font-mono text-text-normal">stream</span> (the data source)
+              and pass it through clauses separated by{' '}
+              <span className="font-mono text-text-normal">|</span>. Each clause filters, shapes,
+              or sorts the data from the previous step.
+            </p>
+            <div className="rounded bg-scheme-shade_2 element-border px-4 py-3 font-mono text-text-normal leading-relaxed">
+              <span className="text-blue-400">messages</span>
+              <span className="text-text-muted">{'  '}← start here (pick a stream)</span>
+              <br />
+              <span className="text-text-muted">| </span>
+              <span className="text-green-400">where rating &gt;= 4</span>
+              <span className="text-text-muted">{'  '}← filter rows</span>
+              <br />
+              <span className="text-text-muted">| </span>
+              <span className="text-yellow-400">order by feedback_submitted_at desc</span>
+              <span className="text-text-muted">{'  '}← sort</span>
+              <br />
+              <span className="text-text-muted">| </span>
+              <span className="text-purple-400">limit 50</span>
+              <span className="text-text-muted">{'  '}← cap results</span>
             </div>
-            <div>
-              <p className="font-mono font-bold text-text-normal mb-2">conversations stream</p>
+            <p className="mt-2 leading-relaxed">
+              You don't need to type queries manually — use the{' '}
+              <strong className="text-text-normal">Basic Query Builder</strong> dropdowns for common
+              filters, or the{' '}
+              <strong className="text-text-normal">Advanced Query Builder</strong> to add any clause.
+              The <strong className="text-text-normal">Textual Query</strong> box always shows the
+              exact query being run and can be edited directly.
+            </p>
+          </div>
+
+          {/* ── Example queries ── */}
+          <div>
+            <p className="font-semibold text-text-normal text-sm mb-3">Example queries</p>
+            <div className="space-y-3">
               {[
-                ['conversation_id','NUMBER','Conversation ID'],
-                ['user_id','NUMBER','Owner user ID'],
-                ['name','TEXT','Auto-generated title'],
-                ['created_at','TIME','When conversation started'],
-                ['message_count','NUMBER','Total message turns'],
-                ['rated_count','NUMBER','Number of rated messages'],
-                ['avg_rating','NUMBER','Mean rating across messages'],
-                ['min_rating','NUMBER','Lowest rating in conv.'],
-                ['max_rating','NUMBER','Highest rating in conv.'],
-                ['last_rated_at','TIME','Most recent rating time'],
-                ['tools_used','ARRAY','Comma-list of distinct tools'],
-              ].map(([f,t,d]) => (
-                <div key={f} className="flex items-baseline gap-2 py-0.5 border-b border-scheme-contrast/10 last:border-0">
-                  <span className="font-mono text-text-normal w-36 shrink-0">{f}</span>
-                  <span className={`text-[10px] px-1 rounded shrink-0 ${
-                    t==='NUMBER'?'bg-blue-600/30 text-blue-300':
-                    t==='TIME'?'bg-yellow-600/30 text-yellow-300':
-                    t==='ARRAY'?'bg-purple-600/30 text-purple-300':
-                    'bg-green-600/30 text-green-300'}`}>{t}</span>
-                  <span>{d}</span>
+                {
+                  label: 'All rated messages, newest first',
+                  query: 'messages\n| where rating != null\n| order by feedback_submitted_at desc\n| limit 100',
+                  note: 'A good starting point. Shows only messages that have been rated.',
+                },
+                {
+                  label: 'Low-rated messages with written feedback',
+                  query: 'messages\n| where rating <= 2\n| where feedback_text != null\n| order by feedback_submitted_at desc\n| limit 50',
+                  note: 'Use this to review the most critical feedback. Both conditions must be true.',
+                },
+                {
+                  label: 'Count of ratings per model',
+                  query: 'messages\n| where rating != null\n| summarize n = count() by model\n| order by n desc',
+                  note: 'Produces a bar chart. Shows which models receive the most feedback.',
+                },
+                {
+                  label: 'Average rating per model',
+                  query: 'messages\n| where rating != null\n| summarize avg_rating = avg(rating) by model\n| order by avg_rating desc',
+                  note: 'Ranks models from highest to lowest average user rating.',
+                },
+                {
+                  label: 'Search feedback text for a keyword',
+                  query: 'messages\n| where feedback_text contains "slow"\n| order by feedback_submitted_at desc\n| limit 50',
+                  note: 'Case-insensitive substring match. Change "slow" to any word or phrase.',
+                },
+                {
+                  label: 'Conversations overview — most-rated first',
+                  query: 'conversations\n| order by rated_count desc\n| limit 50',
+                  note: 'Switch to the conversations stream for one row per conversation rather than per message.',
+                },
+              ].map(({ label, query, note }) => (
+                <div key={label} className="rounded bg-scheme-shade_2 element-border overflow-hidden">
+                  <div className="px-3 py-1.5 border-b border-scheme-contrast/10 font-semibold text-text-normal">
+                    {label}
+                  </div>
+                  <pre className="px-3 py-2 font-mono text-[11px] text-blue-300 leading-relaxed whitespace-pre overflow-x-auto">
+                    {query}
+                  </pre>
+                  <div className="px-3 py-1.5 text-text-muted border-t border-scheme-contrast/10">
+                    {note}
+                  </div>
                 </div>
               ))}
             </div>
           </div>
+
+          {/* ── Tips ── */}
+          <div>
+            <p className="font-semibold text-text-normal text-sm mb-2">Tips for new users</p>
+            <ul className="space-y-1.5 leading-relaxed">
+              <li><span className="text-text-normal font-semibold">Start with Basic Query Builder.</span>{' '}
+                The dropdowns build a valid query automatically — no typing required.</li>
+              <li><span className="text-text-normal font-semibold">Add where clauses one at a time.</span>{' '}
+                Each additional <span className="font-mono">where</span> narrows the results further (AND logic).</li>
+              <li><span className="text-text-normal font-semibold">summarize produces charts.</span>{' '}
+                When a query uses <span className="font-mono">summarize</span>, results automatically
+                render as a bar chart in addition to the table.</li>
+              <li><span className="text-text-normal font-semibold">Always end with limit.</span>{' '}
+                Large queries without a limit can be slow. The Advanced builder adds{' '}
+                <span className="font-mono">limit 200</span> by default.</li>
+              <li><span className="text-text-normal font-semibold">Copy link saves your query.</span>{' '}
+                The Copy link button in Textual Query encodes the current query in the URL so you
+                can bookmark or share it.</li>
+              <li><span className="text-text-normal font-semibold">null means no value.</span>{' '}
+                Most messages don't have a rating — use{' '}
+                <span className="font-mono">where rating != null</span> to exclude them before
+                computing averages.</li>
+            </ul>
+          </div>
+
+          {/* ── Streams & fields ── */}
+          <div>
+            <p className="font-semibold text-text-normal text-sm mb-3">Streams &amp; their fields</p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <p className="font-mono font-bold text-text-normal mb-2">messages</p>
+                <p className="mb-2 leading-relaxed">One row per message turn (user, assistant, or tool call).</p>
+                {[
+                  ['rating','NUMBER','1–5 star rating (null if unrated)'],
+                  ['feedback_text','TEXT','Written comment left by user'],
+                  ['feedback_submitted_at','TIME','When rating was submitted'],
+                  ['model','TEXT','AI model used'],
+                  ['role','TEXT','user / assistant / tool'],
+                  ['content','TEXT','Message text'],
+                  ['user_id','NUMBER','User account ID'],
+                  ['conversation_id','NUMBER','Conversation ID'],
+                  ['tool_call_name','TEXT','Tool used (assistant messages only)'],
+                  ['conversation_tool','ARRAY','All tools used in this conversation'],
+                ].map(([f,t,d]) => (
+                  <div key={f} className="flex items-baseline gap-2 py-0.5 border-b border-scheme-contrast/10 last:border-0">
+                    <span className="font-mono text-text-normal w-44 shrink-0">{f}</span>
+                    <span className={`text-[10px] px-1 rounded shrink-0 ${
+                      t==='NUMBER'?'bg-blue-600/30 text-blue-300':
+                      t==='TIME'?'bg-yellow-600/30 text-yellow-300':
+                      t==='ARRAY'?'bg-purple-600/30 text-purple-300':
+                      'bg-green-600/30 text-green-300'}`}>{t}</span>
+                    <span>{d}</span>
+                  </div>
+                ))}
+              </div>
+              <div>
+                <p className="font-mono font-bold text-text-normal mb-2">conversations</p>
+                <p className="mb-2 leading-relaxed">One row per conversation with pre-computed aggregates.</p>
+                {[
+                  ['conversation_id','NUMBER','Conversation ID'],
+                  ['user_id','NUMBER','Owner user ID'],
+                  ['name','TEXT','Auto-generated title'],
+                  ['created_at','TIME','When conversation started'],
+                  ['message_count','NUMBER','Total message turns'],
+                  ['rated_count','NUMBER','Number of rated messages'],
+                  ['avg_rating','NUMBER','Mean rating across messages'],
+                  ['min_rating','NUMBER','Lowest rating in conv.'],
+                  ['max_rating','NUMBER','Highest rating in conv.'],
+                  ['last_rated_at','TIME','Most recent rating time'],
+                  ['tools_used','ARRAY','Comma-list of distinct tools used'],
+                ].map(([f,t,d]) => (
+                  <div key={f} className="flex items-baseline gap-2 py-0.5 border-b border-scheme-contrast/10 last:border-0">
+                    <span className="font-mono text-text-normal w-36 shrink-0">{f}</span>
+                    <span className={`text-[10px] px-1 rounded shrink-0 ${
+                      t==='NUMBER'?'bg-blue-600/30 text-blue-300':
+                      t==='TIME'?'bg-yellow-600/30 text-yellow-300':
+                      t==='ARRAY'?'bg-purple-600/30 text-purple-300':
+                      'bg-green-600/30 text-green-300'}`}>{t}</span>
+                    <span>{d}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* ── Operators & aggregation ── */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <p className="font-semibold text-text-normal mb-1">Operators</p>
-              {['== / !=  equal / not equal','< > <= >=  numeric','contains "x"  substring','startswith "x"  prefix','in [1,2,3]  membership','== null / != null  missing/present'].map(o => (
-                <div key={o} className="font-mono text-text-normal/80 py-0.5 text-[11px]">{o}</div>
+              <p className="font-semibold text-text-normal mb-2">Comparison operators</p>
+              {[
+                ['== / !=', 'Equal / not equal'],
+                ['< > <= >=', 'Numeric comparisons'],
+                ['contains "x"', 'Case-insensitive substring match'],
+                ['startswith "x"', 'Prefix match'],
+                ['in [1, 2, 3]', 'Matches any value in the list'],
+                ['== null / != null', 'Field is empty / field has a value'],
+              ].map(([op, desc]) => (
+                <div key={op} className="flex gap-3 py-0.5 border-b border-scheme-contrast/10 last:border-0">
+                  <span className="font-mono text-text-normal w-36 shrink-0">{op}</span>
+                  <span>{desc}</span>
+                </div>
               ))}
             </div>
             <div>
-              <p className="font-semibold text-text-normal mb-1">Aggregation functions</p>
-              {['avg(field)','count()','min(field)','max(field)','sum(field)','median(field)'].map(f => (
-                <div key={f} className="font-mono text-text-normal/80 py-0.5 text-[11px]">{f}</div>
+              <p className="font-semibold text-text-normal mb-2">Aggregation functions (for summarize)</p>
+              {[
+                ['count()', 'Number of rows in each group'],
+                ['avg(field)', 'Average value'],
+                ['min(field)', 'Lowest value'],
+                ['max(field)', 'Highest value'],
+                ['sum(field)', 'Total of all values'],
+                ['median(field)', 'Middle value'],
+              ].map(([fn, desc]) => (
+                <div key={fn} className="flex gap-3 py-0.5 border-b border-scheme-contrast/10 last:border-0">
+                  <span className="font-mono text-text-normal w-36 shrink-0">{fn}</span>
+                  <span>{desc}</span>
+                </div>
               ))}
             </div>
           </div>
+
         </div>
       </details>
 

--- a/react/src/features/platform_admin/components/feedback-dashboard/FilterBar.tsx
+++ b/react/src/features/platform_admin/components/feedback-dashboard/FilterBar.tsx
@@ -12,7 +12,7 @@ interface FilterBarProps {
   options: FilterOptions;
   optionsLoading: boolean;
   hasActiveFilters: boolean;
-  onFilterChange: (key: keyof FilterState, value: string | number) => void;
+  onFilterChange: (key: keyof FilterState, value: string) => void;
   onReset: () => void;
   /** When true, suppresses the built-in "Filters" header row (use inside DashboardSection) */
   hideHeader?: boolean;
@@ -237,20 +237,6 @@ const FilterBar: React.FC<FilterBarProps> = ({
           placeholder="Either"
         />
 
-        {/* result limit */}
-        <FilterSelect
-          label="Result limit"
-          value={String(filters.limit)}
-          onChange={v => onFilterChange('limit', Number(v))}
-          options={[
-            { value: '50',   label: '50 rows'   },
-            { value: '100',  label: '100 rows'  },
-            { value: '200',  label: '200 rows'  },
-            { value: '500',  label: '500 rows'  },
-            { value: '1000', label: '1000 rows' },
-          ]}
-          placeholder=""
-        />
       </div>
     </div>
   );

--- a/react/src/features/platform_admin/components/feedback-dashboard/QueryBuilder.tsx
+++ b/react/src/features/platform_admin/components/feedback-dashboard/QueryBuilder.tsx
@@ -1,4 +1,9 @@
 import React, { useState } from 'react';
+import type { AdvancedState, WhereRow, SummarizeRow, OrderByRow } from './useAdvancedBuilder';
+
+// ---------------------------------------------------------------------------
+// Field / operator constants
+// ---------------------------------------------------------------------------
 
 const FIELDS = [
   'rating', 'feedback_text', 'feedback_submitted_at', 'model', 'role', 'content',
@@ -6,310 +11,347 @@ const FIELDS = [
   'conversation_id', 'conversation_tool',
 ] as const;
 
-const NUMERIC_FIELDS = new Set(['rating', 'sequence_number', 'user_id', 'conversation_id']);
-const SELECTABLE_FIELDS = FIELDS.filter((f) => f !== 'conversation_tool');
+const SELECTABLE_FIELDS = FIELDS.filter(f => f !== 'conversation_tool');
 
 const OPERATORS = [
-  { value: '==', label: '== (equals)' },
-  { value: '!=', label: '!= (not equals)' },
-  { value: '<', label: '< (less than)' },
-  { value: '>', label: '> (greater than)' },
-  { value: '<=', label: '<= (less or equal)' },
-  { value: '>=', label: '>= (greater or equal)' },
-  { value: 'contains', label: 'contains' },
-  { value: 'startswith', label: 'startswith' },
-  { value: 'in', label: 'in [list]' },
-  { value: '== null', label: 'is null' },
-  { value: '!= null', label: 'is not null' },
+  { value: '==',     label: '== (equals)'      },
+  { value: '!=',     label: '!= (not equals)'   },
+  { value: '<',      label: '< (less than)'     },
+  { value: '>',      label: '> (greater than)'  },
+  { value: '<=',     label: '<= (less or equal)'},
+  { value: '>=',     label: '>= (greater or equal)'},
+  { value: 'contains',   label: 'contains'      },
+  { value: 'startswith', label: 'startswith'    },
+  { value: 'in',         label: 'in [list]'     },
+  { value: '== null',    label: 'is null'       },
+  { value: '!= null',    label: 'is not null'   },
 ] as const;
 
 const AGG_FUNCTIONS = ['count', 'avg', 'min', 'max', 'sum', 'median'] as const;
 
-export type Props = {
-  value: string;
-  onChange: (v: string) => void;
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export type QueryBuilderAdvancedProps = {
+  state: AdvancedState;
+  onAddWhere:       (field: string, op: string, value: string) => void;
+  onRemoveWhere:    (id: string) => void;
+  onAddSummarize:   (alias: string, func: string, field: string, byField: string) => void;
+  onRemoveSummarize:(id: string) => void;
+  onToggleSelect:   (field: string) => void;
+  onRemoveSelect:   (field: string) => void;
+  onAddOrderBy:     (field: string, dir: 'asc' | 'desc') => void;
+  onRemoveOrderBy:  (id: string) => void;
+  onSetLimit:       (n: number) => void;
 };
 
-function quoteIfString(field: string, raw: string): string {
-  const trimmed = raw.trim();
-  if (NUMERIC_FIELDS.has(field)) return trimmed;
-  return `"${trimmed.replace(/"/g, '\\"')}"`;
-}
+// ---------------------------------------------------------------------------
+// Small shared components
+// ---------------------------------------------------------------------------
 
-function formatValueList(field: string, raw: string): string {
-  const parts = raw.split(',').map((s) => s.trim()).filter(Boolean);
-  const items = parts.map((p) => {
-    if (NUMERIC_FIELDS.has(field)) return p;
-    return `"${p.replace(/"/g, '\\"')}"`;
-  });
-  return `[${items.join(', ')}]`;
-}
+const Trash: React.FC<{ onClick: () => void; title?: string }> = ({ onClick, title = 'Remove' }) => (
+  <button
+    onClick={onClick}
+    title={title}
+    className="text-text-muted hover:text-red-400 transition-colors flex-shrink-0 p-0.5"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 24 24"
+      fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="3 6 5 6 21 6" />
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+      <path d="M10 11v6M14 11v6" />
+      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+    </svg>
+  </button>
+);
 
-function appendStage(current: string, stage: string): string {
-  const trimmed = current.trim();
-  if (!trimmed) return `messages\n| ${stage}`;
-  return `${trimmed}\n| ${stage}`;
-}
+const selectCls =
+  'px-2 py-1 rounded bg-scheme-shade_3 element-border font-mono text-xs';
+const inputCls =
+  'px-2 py-1 rounded bg-scheme-shade_3 element-border font-mono text-xs';
+const addBtnCls =
+  'px-3 py-1 rounded bg-blue-600 hover:bg-blue-700 text-white font-semibold text-xs active:scale-95 transition-all';
+
+// Row pill displayed under each section
+const ClausePill: React.FC<{ label: string; onRemove: () => void }> = ({ label, onRemove }) => (
+  <div className="flex items-center gap-1.5 px-2 py-1 rounded bg-scheme-shade_3 element-border font-mono text-xs w-full">
+    <span className="flex-1 text-text-normal truncate">{label}</span>
+    <Trash onClick={onRemove} />
+  </div>
+);
 
 // ---------------------------------------------------------------------------
-// QueryBuilderAdvanced — full visual builder (where, select, summarize,
-// order by, limit) in one combined panel
+// Main component
 // ---------------------------------------------------------------------------
-export const QueryBuilderAdvanced: React.FC<Props> = ({ value, onChange }) => {
+
+export const QueryBuilderAdvanced: React.FC<QueryBuilderAdvancedProps> = ({
+  state,
+  onAddWhere, onRemoveWhere,
+  onAddSummarize, onRemoveSummarize,
+  onToggleSelect, onRemoveSelect,
+  onAddOrderBy, onRemoveOrderBy,
+  onSetLimit,
+}) => {
+  // ── where input state ──────────────────────────────────────────────────
   const [wField, setWField] = useState<string>('rating');
-  const [wOp, setWOp] = useState<string>('==');
+  const [wOp,    setWOp]    = useState<string>('==');
   const [wValue, setWValue] = useState<string>('');
 
-  const [selectedFields, setSelectedFields] = useState<string[]>([]);
-
-  const [summAlias, setSummAlias] = useState<string>('n');
-  const [summFunc, setSummFunc] = useState<string>('count');
-  const [summField, setSummField] = useState<string>('rating');
+  // ── summarize input state ──────────────────────────────────────────────
+  const [summAlias,   setSummAlias]   = useState<string>('n');
+  const [summFunc,    setSummFunc]    = useState<string>('count');
+  const [summField,   setSummField]   = useState<string>('rating');
   const [summByField, setSummByField] = useState<string>('');
 
+  // ── order by input state ───────────────────────────────────────────────
   const [orderField, setOrderField] = useState<string>('');
-  const [orderDir, setOrderDir] = useState<string>('desc');
+  const [orderDir,   setOrderDir]   = useState<'asc' | 'desc'>('desc');
 
-  const [limitValue, setLimitValue] = useState<string>('20');
-
-  const addWhere = () => {
-    if (wOp === '== null' || wOp === '!= null') {
-      onChange(appendStage(value, `where ${wField} ${wOp}`));
-      return;
-    }
-    if (wOp === 'in') {
-      if (!wValue.trim()) return;
-      onChange(appendStage(value, `where ${wField} in ${formatValueList(wField, wValue)}`));
-      setWValue('');
-      return;
-    }
-    if (!wValue.trim()) return;
-    onChange(appendStage(value, `where ${wField} ${wOp} ${quoteIfString(wField, wValue)}`));
+  // ── handlers ──────────────────────────────────────────────────────────
+  const handleAddWhere = () => {
+    if (wOp !== '== null' && wOp !== '!= null' && !wValue.trim()) return;
+    onAddWhere(wField, wOp, wValue.trim());
     setWValue('');
   };
 
-  const toggleSelectField = (field: string) => {
-    setSelectedFields((prev) =>
-      prev.includes(field) ? prev.filter((f) => f !== field) : [...prev, field],
-    );
-  };
-
-  const addSelect = () => {
-    if (selectedFields.length === 0) return;
-    onChange(appendStage(value, `select ${selectedFields.join(', ')}`));
-    setSelectedFields([]);
-  };
-
-  const addSummarize = () => {
-    const alias = summAlias.trim() || 'n';
+  const handleAddSummarize = () => {
     if (summFunc !== 'count' && !summField) return;
-    const inner = summFunc === 'count' ? '' : summField;
-    let stage = `summarize ${alias} = ${summFunc}(${inner})`;
-    if (summByField) stage += ` by ${summByField}`;
-    onChange(appendStage(value, stage));
+    onAddSummarize(summAlias.trim() || 'n', summFunc, summField, summByField);
   };
 
-  const addOrderBy = () => {
-    const f = orderField.trim();
-    if (!f) return;
-    onChange(appendStage(value, `order by ${f} ${orderDir}`));
+  const handleAddOrderBy = () => {
+    if (!orderField.trim()) return;
+    onAddOrderBy(orderField.trim(), orderDir);
+    setOrderField('');
   };
 
-  const addLimit = () => {
-    const n = parseInt(limitValue, 10);
-    if (!n || n <= 0) return;
-    onChange(appendStage(value, `limit ${n}`));
+  // ── human-readable label for a where row ──────────────────────────────
+  const whereLabel = (row: WhereRow) => {
+    if (row.op === '== null' || row.op === '!= null') return `${row.field} ${row.op}`;
+    if (!row.value) return `${row.field} ${row.op}`;
+    return `${row.field} ${row.op} ${row.value}`;
   };
 
+  const summarizeLabel = (row: SummarizeRow) => {
+    const inner = row.func === 'count' ? '' : row.field;
+    let s = `${row.alias} = ${row.func}(${inner})`;
+    if (row.byField) s += ` by ${row.byField}`;
+    return s;
+  };
+
+  const orderByLabel = (row: OrderByRow) => `${row.field} ${row.dir}`;
+
+  // ── render ─────────────────────────────────────────────────────────────
   return (
     <div className="px-4 pt-2 space-y-5 text-xs pb-6">
       <p className="text-text-muted leading-relaxed">
-        Click the buttons below to build a query. Each click appends a clause to the Textual Query
-        box. Add clauses in order:{' '}
+        Add clauses in order:{' '}
         <span className="font-mono text-text-normal">
           where → summarize → select → order by → limit
         </span>.
+        Each clause stacks below its section and appears instantly in Textual Query.
         The builder only generates{' '}
-        <span className="font-mono text-text-normal">messages</span>-stream queries; type{' '}
-        <span className="font-mono text-text-normal">conversations | …</span> directly in Textual
-        Query for conversation-level queries.
+        <span className="font-mono text-text-normal">messages</span>-stream queries.
       </p>
 
-      {/* WHERE */}
-      <div className="p-4 rounded bg-scheme-shade_2 element-border">
-        <div className="font-semibold text-text-normal mb-2">Filter rows (where)</div>
+      {/* ── WHERE ─────────────────────────────────────────────────────── */}
+      <div className="p-4 rounded bg-scheme-shade_2 element-border space-y-3">
+        <div className="font-semibold text-text-normal">Filter rows (where)</div>
+
+        {/* Existing where rows */}
+        {state.whereRows.length > 0 && (
+          <div className="space-y-1">
+            {state.whereRows.map(row => (
+              <ClausePill
+                key={row.id}
+                label={`where ${whereLabel(row)}`}
+                onRemove={() => onRemoveWhere(row.id)}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Add where controls */}
         <div className="flex flex-wrap gap-2 items-center">
-          <select
-            value={wField}
-            onChange={(e) => setWField(e.target.value)}
-            className="px-2 py-1 rounded bg-scheme-shade_3 element-border font-mono"
-          >
-            {FIELDS.map((f) => <option key={f} value={f}>{f}</option>)}
+          <select value={wField} onChange={e => setWField(e.target.value)} className={selectCls}>
+            {FIELDS.map(f => <option key={f} value={f}>{f}</option>)}
           </select>
-          <select
-            value={wOp}
-            onChange={(e) => setWOp(e.target.value)}
-            className="px-2 py-1 rounded bg-scheme-shade_3 element-border font-mono"
-          >
-            {OPERATORS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+          <select value={wOp} onChange={e => setWOp(e.target.value)} className={selectCls}>
+            {OPERATORS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
           </select>
           {wOp !== '== null' && wOp !== '!= null' && (
             <input
               type="text"
               placeholder={wOp === 'in' ? 'value1, value2, …' : 'value'}
               value={wValue}
-              onChange={(e) => setWValue(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addWhere(); } }}
-              className="px-2 py-1 rounded bg-scheme-shade_3 element-border font-mono w-48"
+              onChange={e => setWValue(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); handleAddWhere(); } }}
+              className={`${inputCls} w-40`}
             />
           )}
-          <button
-            onClick={addWhere}
-            className="px-3 py-1 rounded bg-blue-600 hover:bg-blue-700 text-white font-semibold active:scale-95 transition-all"
-          >
-            Add where
-          </button>
+          <button onClick={handleAddWhere} className={addBtnCls}>Add where</button>
         </div>
+
         {wOp === 'in' && (
-          <p className="text-text-muted/80 mt-2 leading-relaxed">
+          <p className="text-text-muted/80 leading-relaxed">
             Comma-separated values, e.g.{' '}
             <span className="font-mono text-text-normal">1, 2, 3</span> or{' '}
             <span className="font-mono text-text-normal">claude-3, gpt-4o</span>.
           </p>
         )}
         {(wOp === '== null' || wOp === '!= null') && (
-          <p className="text-text-muted/80 mt-2 leading-relaxed">
+          <p className="text-text-muted/80 leading-relaxed">
             No value needed — matches rows where the field is (or isn't) empty.
           </p>
         )}
       </div>
 
-      {/* SUMMARIZE */}
-      <div className="p-4 rounded bg-scheme-shade_2 element-border">
-        <div className="font-semibold text-text-normal mb-2">Group &amp; aggregate (summarize)</div>
+      {/* ── SUMMARIZE ─────────────────────────────────────────────────── */}
+      <div className="p-4 rounded bg-scheme-shade_2 element-border space-y-3">
+        <div className="font-semibold text-text-normal">Group &amp; aggregate (summarize)</div>
+
+        {state.summarizeRows.length > 0 && (
+          <div className="space-y-1">
+            {state.summarizeRows.map(row => (
+              <ClausePill
+                key={row.id}
+                label={`summarize ${summarizeLabel(row)}`}
+                onRemove={() => onRemoveSummarize(row.id)}
+              />
+            ))}
+          </div>
+        )}
+
         <div className="flex flex-wrap gap-2 items-center">
           <input
             value={summAlias}
-            onChange={(e) => setSummAlias(e.target.value)}
-            placeholder="name"
-            className="px-2 py-1 rounded bg-scheme-shade_3 element-border font-mono w-24"
+            onChange={e => setSummAlias(e.target.value)}
+            placeholder="alias"
+            className={`${inputCls} w-20`}
           />
           <span className="font-mono">=</span>
-          <select
-            value={summFunc}
-            onChange={(e) => setSummFunc(e.target.value)}
-            className="px-2 py-1 rounded bg-scheme-shade_3 element-border font-mono"
-          >
-            {AGG_FUNCTIONS.map((f) => <option key={f} value={f}>{f}</option>)}
+          <select value={summFunc} onChange={e => setSummFunc(e.target.value)} className={selectCls}>
+            {AGG_FUNCTIONS.map(f => <option key={f} value={f}>{f}</option>)}
           </select>
           {summFunc !== 'count' && (
-            <select
-              value={summField}
-              onChange={(e) => setSummField(e.target.value)}
-              className="px-2 py-1 rounded bg-scheme-shade_3 element-border font-mono"
-            >
-              {SELECTABLE_FIELDS.map((f) => <option key={f} value={f}>{f}</option>)}
+            <select value={summField} onChange={e => setSummField(e.target.value)} className={selectCls}>
+              {SELECTABLE_FIELDS.map(f => <option key={f} value={f}>{f}</option>)}
             </select>
           )}
           <span className="font-mono">by</span>
-          <select
-            value={summByField}
-            onChange={(e) => setSummByField(e.target.value)}
-            className="px-2 py-1 rounded bg-scheme-shade_3 element-border font-mono"
-          >
+          <select value={summByField} onChange={e => setSummByField(e.target.value)} className={selectCls}>
             <option value="">— none —</option>
-            {SELECTABLE_FIELDS.map((f) => <option key={f} value={f}>{f}</option>)}
+            {SELECTABLE_FIELDS.map(f => <option key={f} value={f}>{f}</option>)}
           </select>
-          <button
-            onClick={addSummarize}
-            className="px-3 py-1 rounded bg-blue-600 hover:bg-blue-700 text-white font-semibold active:scale-95 transition-all"
-          >
-            Add summarize
-          </button>
+          <button onClick={handleAddSummarize} className={addBtnCls}>Add summarize</button>
         </div>
       </div>
 
-      {/* SELECT */}
-      <div className="p-4 rounded bg-scheme-shade_2 element-border">
-        <div className="font-semibold text-text-normal mb-2">Choose columns (select)</div>
-        <div className="flex flex-wrap gap-3">
-          {SELECTABLE_FIELDS.map((f) => {
-            const checked = selectedFields.includes(f);
+      {/* ── SELECT ────────────────────────────────────────────────────── */}
+      <div className="p-4 rounded bg-scheme-shade_2 element-border space-y-3">
+        <div className="font-semibold text-text-normal">Choose columns (select)</div>
+
+        {/* Selected field tags */}
+        {state.selectFields.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {state.selectFields.map(f => (
+              <span
+                key={f}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-blue-600/30 element-border font-mono text-xs"
+              >
+                {f}
+                <Trash onClick={() => onRemoveSelect(f)} title={`Remove ${f}`} />
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Checkbox grid for toggling */}
+        <div className="flex flex-wrap gap-2">
+          {SELECTABLE_FIELDS.map(f => {
+            const checked = state.selectFields.includes(f);
             return (
               <label
                 key={f}
-                className={`flex items-center gap-2 font-mono cursor-pointer px-3 py-1.5 rounded element-border ${
+                className={`flex items-center gap-1.5 font-mono cursor-pointer px-2 py-1 rounded element-border text-xs ${
                   checked ? 'bg-blue-600/30' : 'bg-scheme-shade_3 hover:bg-scheme-shade_5'
                 }`}
               >
                 <input
                   type="checkbox"
                   checked={checked}
-                  onChange={() => toggleSelectField(f)}
+                  onChange={() => onToggleSelect(f)}
+                  className="w-3 h-3"
                 />
                 {f}
               </label>
             );
           })}
         </div>
-        <button
-          onClick={addSelect}
-          className="mt-4 px-3 py-1 rounded bg-blue-600 hover:bg-blue-700 text-white font-semibold active:scale-95 transition-all"
-        >
-          Add select
-        </button>
+        {state.selectFields.length === 0 && (
+          <p className="text-text-muted/80 leading-relaxed">
+            Check fields above to add a <span className="font-mono text-text-normal">select</span> clause.
+          </p>
+        )}
       </div>
 
-      {/* ORDER BY + LIMIT */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <div className="p-4 rounded bg-scheme-shade_2 element-border">
-          <div className="font-semibold text-text-normal mb-2">Sort (order by)</div>
-          <div className="flex flex-wrap gap-2 items-center">
-            <input
-              value={orderField}
-              onChange={(e) => setOrderField(e.target.value)}
-              placeholder="field or alias"
-              className="px-2 py-1 rounded bg-scheme-shade_3 element-border font-mono w-40"
-            />
-            <select
-              value={orderDir}
-              onChange={(e) => setOrderDir(e.target.value)}
-              className="px-2 py-1 rounded bg-scheme-shade_3 element-border font-mono"
-            >
-              <option value="asc">asc</option>
-              <option value="desc">desc</option>
-            </select>
-            <button
-              onClick={addOrderBy}
-              className="px-3 py-1 rounded bg-blue-600 hover:bg-blue-700 text-white font-semibold active:scale-95 transition-all"
-            >
-              Add order by
-            </button>
+      {/* ── ORDER BY ──────────────────────────────────────────────────── */}
+      <div className="p-4 rounded bg-scheme-shade_2 element-border space-y-3">
+        <div className="font-semibold text-text-normal">Sort (order by)</div>
+
+        {state.orderByRows.length > 0 && (
+          <div className="space-y-1">
+            {state.orderByRows.map(row => (
+              <ClausePill
+                key={row.id}
+                label={`order by ${orderByLabel(row)}`}
+                onRemove={() => onRemoveOrderBy(row.id)}
+              />
+            ))}
           </div>
+        )}
+
+        <div className="flex flex-wrap gap-2 items-center">
+          <input
+            value={orderField}
+            onChange={e => setOrderField(e.target.value)}
+            placeholder="field or alias"
+            className={`${inputCls} w-36`}
+          />
+          <select
+            value={orderDir}
+            onChange={e => setOrderDir(e.target.value as 'asc' | 'desc')}
+            className={selectCls}
+          >
+            <option value="asc">asc</option>
+            <option value="desc">desc</option>
+          </select>
+          <button onClick={handleAddOrderBy} className={addBtnCls}>Add order by</button>
         </div>
-        <div className="p-4 rounded bg-scheme-shade_2 element-border">
-          <div className="font-semibold text-text-normal mb-2">Row cap (limit)</div>
-          <div className="flex flex-wrap gap-2 items-center">
-            <input
-              type="number"
-              min={1}
-              value={limitValue}
-              onChange={(e) => setLimitValue(e.target.value)}
-              className="px-2 py-1 rounded bg-scheme-shade_3 element-border font-mono w-24"
-            />
-            <button
-              onClick={addLimit}
-              className="px-3 py-1 rounded bg-blue-600 hover:bg-blue-700 text-white font-semibold active:scale-95 transition-all"
-            >
-              Add limit
-            </button>
-          </div>
+      </div>
+
+      {/* ── LIMIT ─────────────────────────────────────────────────────── */}
+      <div className="p-4 rounded bg-scheme-shade_2 element-border">
+        <div className="font-semibold text-text-normal mb-2">Row cap (limit)</div>
+        <div className="flex flex-wrap gap-2 items-center">
+          <input
+            type="number"
+            min={1}
+            value={state.limitValue}
+            onChange={e => {
+              const n = parseInt(e.target.value, 10);
+              if (!Number.isNaN(n) && n > 0) onSetLimit(n);
+            }}
+            className={`${inputCls} w-24`}
+          />
+          <span className="text-text-muted">rows</span>
         </div>
       </div>
     </div>
   );
 };
 
-// Default export kept for any legacy imports
+// Default export for legacy imports
 const QueryBuilder = QueryBuilderAdvanced;
 export default QueryBuilder;

--- a/react/src/features/platform_admin/components/feedback-dashboard/useAdvancedBuilder.ts
+++ b/react/src/features/platform_admin/components/feedback-dashboard/useAdvancedBuilder.ts
@@ -1,0 +1,256 @@
+// useAdvancedBuilder.ts
+// owns the Advanced Query Builder's clause state
+// each clause type (where, summarize, select, order by, limit) is a proper list with IDs
+// the hook is the source of truth for the Advanced section;
+// the Textual Query textarea is derived from Basic + Advanced combined.
+import { useState, useCallback } from 'react';
+
+const NUMERIC_FIELDS = new Set(['rating', 'sequence_number', 'user_id', 'conversation_id']);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type WhereRow = {
+  id: string;
+  field: string;
+  op: string;
+  value: string;
+};
+
+export type SummarizeRow = {
+  id: string;
+  alias: string;
+  func: string;
+  field: string;    // empty string for count()
+  byField: string;  // empty string for no grouping
+};
+
+export type OrderByRow = {
+  id: string;
+  field: string;
+  dir: 'asc' | 'desc';
+};
+
+export type AdvancedState = {
+  whereRows: WhereRow[];
+  summarizeRows: SummarizeRow[];
+  selectFields: string[];
+  orderByRows: OrderByRow[];
+  limitValue: number;
+};
+
+// Used when parsing KQL back into Advanced state
+export type ParsedAdvanced = {
+  whereRows: Omit<WhereRow, 'id'>[];
+  summarizeRows: Omit<SummarizeRow, 'id'>[];
+  selectFields: string[];
+  orderByRows: Omit<OrderByRow, 'id'>[];
+  limitValue: number | null;
+};
+
+// ---------------------------------------------------------------------------
+// ID generator
+// ---------------------------------------------------------------------------
+
+let _idCounter = 0;
+function nextId(): string {
+  return `adv-${++_idCounter}`;
+}
+
+// ---------------------------------------------------------------------------
+// KQL builders
+// ---------------------------------------------------------------------------
+
+function buildWhereClause(row: WhereRow): string {
+  if (row.op === '== null' || row.op === '!= null') {
+    return `where ${row.field} ${row.op}`;
+  }
+  if (row.op === 'in') {
+    const parts = row.value.split(',').map(s => s.trim()).filter(Boolean);
+    const items = parts.map(p =>
+      NUMERIC_FIELDS.has(row.field) ? p : `"${p.replace(/"/g, '\\"')}"`
+    );
+    return `where ${row.field} in [${items.join(', ')}]`;
+  }
+  if (row.op === 'contains' || row.op === 'startswith') {
+    return `where ${row.field} ${row.op} "${row.value.replace(/"/g, '\\"')}"`;
+  }
+  const val = NUMERIC_FIELDS.has(row.field)
+    ? row.value.trim()
+    : `"${row.value.trim().replace(/"/g, '\\"')}"`;
+  return `where ${row.field} ${row.op} ${val}`;
+}
+
+function buildSummarizeClause(row: SummarizeRow): string {
+  const inner = row.func === 'count' ? '' : row.field;
+  let clause = `summarize ${row.alias} = ${row.func}(${inner})`;
+  if (row.byField) clause += ` by ${row.byField}`;
+  return clause;
+}
+
+// Returns an array of pipe-clause strings (no "messages" prefix, no leading "|")
+export function buildAdvancedClauses(state: AdvancedState): string[] {
+  const clauses: string[] = [];
+
+  for (const row of state.whereRows) {
+    clauses.push(buildWhereClause(row));
+  }
+  for (const row of state.summarizeRows) {
+    clauses.push(buildSummarizeClause(row));
+  }
+  if (state.selectFields.length > 0) {
+    clauses.push(`select ${state.selectFields.join(', ')}`);
+  }
+  // After summarize, original stream fields like feedback_submitted_at no longer
+  // exist in the result set. Replace any order by on that field with an order by
+  // the first summarize alias (e.g. "n") so results are still meaningfully sorted.
+  let effectiveOrderBy = state.orderByRows;
+  if (state.summarizeRows.length > 0) {
+    const filtered = state.orderByRows.filter(r => r.field !== 'feedback_submitted_at');
+    if (filtered.length === 0) {
+      // No valid order by left — default to the first summarize alias descending
+      const defaultAlias = state.summarizeRows[0]?.alias || 'n';
+      effectiveOrderBy = [{ id: 'auto-order', field: defaultAlias, dir: 'desc' }];
+    } else {
+      effectiveOrderBy = filtered;
+    }
+  }
+
+  for (const row of effectiveOrderBy) {
+    clauses.push(`order by ${row.field} ${row.dir}`);
+  }
+  clauses.push(`limit ${state.limitValue}`);
+
+  return clauses;
+}
+
+// ---------------------------------------------------------------------------
+// Default state — always includes a sensible order by and limit so queries
+// are never accidentally unordered or unbounded.
+// ---------------------------------------------------------------------------
+
+const DEFAULT_ORDER_ROW: OrderByRow = {
+  id: 'default-order',
+  field: 'feedback_submitted_at',
+  dir: 'desc',
+};
+
+const INITIAL_STATE: AdvancedState = {
+  whereRows: [],
+  summarizeRows: [],
+  selectFields: [],
+  orderByRows: [DEFAULT_ORDER_ROW],
+  limitValue: 200,
+};
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useAdvancedBuilder() {
+  const [state, setState] = useState<AdvancedState>(INITIAL_STATE);
+
+  // WHERE
+  const addWhere = useCallback((field: string, op: string, value: string) => {
+    setState(prev => ({
+      ...prev,
+      whereRows: [...prev.whereRows, { id: nextId(), field, op, value }],
+    }));
+  }, []);
+
+  const removeWhere = useCallback((id: string) => {
+    setState(prev => ({ ...prev, whereRows: prev.whereRows.filter(r => r.id !== id) }));
+  }, []);
+
+  // SUMMARIZE
+  const addSummarize = useCallback(
+    (alias: string, func: string, field: string, byField: string) => {
+      setState(prev => ({
+        ...prev,
+        summarizeRows: [...prev.summarizeRows, { id: nextId(), alias, func, field, byField }],
+      }));
+    },
+    [],
+  );
+
+  const removeSummarize = useCallback((id: string) => {
+    setState(prev => ({
+      ...prev,
+      summarizeRows: prev.summarizeRows.filter(r => r.id !== id),
+    }));
+  }, []);
+
+  // SELECT (toggle individual fields)
+  const toggleSelect = useCallback((field: string) => {
+    setState(prev => ({
+      ...prev,
+      selectFields: prev.selectFields.includes(field)
+        ? prev.selectFields.filter(f => f !== field)
+        : [...prev.selectFields, field],
+    }));
+  }, []);
+
+  const removeSelect = useCallback((field: string) => {
+    setState(prev => ({
+      ...prev,
+      selectFields: prev.selectFields.filter(f => f !== field),
+    }));
+  }, []);
+
+  // ORDER BY
+  const addOrderBy = useCallback((field: string, dir: 'asc' | 'desc') => {
+    setState(prev => ({
+      ...prev,
+      orderByRows: [...prev.orderByRows, { id: nextId(), field, dir }],
+    }));
+  }, []);
+
+  const removeOrderBy = useCallback((id: string) => {
+    setState(prev => ({
+      ...prev,
+      orderByRows: prev.orderByRows.filter(r => r.id !== id),
+    }));
+  }, []);
+
+  // LIMIT
+  const setLimitValue = useCallback((n: number) => {
+    setState(prev => ({ ...prev, limitValue: n }));
+  }, []);
+
+  // Set entire Advanced state from parsed KQL (used when textarea is edited)
+  const setFromParsed = useCallback((parsed: ParsedAdvanced) => {
+    setState({
+      whereRows: parsed.whereRows.map(r => ({ ...r, id: nextId() })),
+      summarizeRows: parsed.summarizeRows.map(r => ({ ...r, id: nextId() })),
+      selectFields: parsed.selectFields,
+      orderByRows:
+        parsed.orderByRows.length > 0
+          ? parsed.orderByRows.map(r => ({ ...r, id: nextId() }))
+          : [{ ...DEFAULT_ORDER_ROW, id: nextId() }],
+      limitValue: parsed.limitValue ?? 200,
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    setState({
+      ...INITIAL_STATE,
+      orderByRows: [{ ...DEFAULT_ORDER_ROW, id: nextId() }],
+    });
+  }, []);
+
+  return {
+    state,
+    addWhere,
+    removeWhere,
+    addSummarize,
+    removeSummarize,
+    toggleSelect,
+    removeSelect,
+    addOrderBy,
+    removeOrderBy,
+    setLimitValue,
+    setFromParsed,
+    reset,
+  };
+}

--- a/react/src/features/platform_admin/components/feedback-dashboard/useFilterBar.ts
+++ b/react/src/features/platform_admin/components/feedback-dashboard/useFilterBar.ts
@@ -1,8 +1,7 @@
 // useFilterBar.ts
-// owns filter state for the filter bar
-// builds a KQL query string from active filters
-// debounces text inputs so we do not fire a query on every keystroke
-// the generated KQL is used both for live display and for actual execution
+// owns filter state for the basic query builder dropdowns
+// builds the basic KQL clauses (where only — order by and limit live in useAdvancedBuilder)
+// debounces feedback_text_search so queries don't fire on every keystroke
 import { useState, useEffect, useRef, useCallback } from 'react';
 
 const DEBOUNCE_MS = 400;
@@ -19,7 +18,6 @@ export interface FilterState {
   model: string;
   tool_call_name: string;
   has_feedback_text: string;
-  limit: number;
 }
 
 export const EMPTY_FILTER_STATE: FilterState = {
@@ -34,11 +32,12 @@ export const EMPTY_FILTER_STATE: FilterState = {
   model: '',
   tool_call_name: '',
   has_feedback_text: '',
-  limit: 200,
 };
 
-export function buildKQLFromFilters(filters: FilterState): string {
-  const clauses: string[] = ['messages'];
+// Builds only the Basic where clauses — no order by, no limit.
+// order by and limit are owned by useAdvancedBuilder.
+export function buildBasicClauses(filters: FilterState, feedbackTextSearch: string): string[] {
+  const clauses: string[] = [];
 
   if (filters.date_from)
     clauses.push(`where feedback_submitted_at >= "${filters.date_from}"`);
@@ -75,25 +74,19 @@ export function buildKQLFromFilters(filters: FilterState): string {
   else if (filters.has_feedback_text === 'false')
     clauses.push('where feedback_text == null');
 
-  if (filters.feedback_text_search.trim()) {
-    const escaped = filters.feedback_text_search.trim().replace(/"/g, '\\"');
+  if (feedbackTextSearch.trim()) {
+    const escaped = feedbackTextSearch.trim().replace(/"/g, '\\"');
     clauses.push(`where feedback_text contains "${escaped}"`);
   }
 
-  clauses.push('order by feedback_submitted_at desc');
-  clauses.push(`limit ${filters.limit}`);
-
-  const [first, ...rest] = clauses;
-  if (rest.length === 0) return first;
-  return `${first}\n${rest.map(c => `| ${c}`).join('\n')}`;
+  return clauses;
 }
 
 export function useFilterBar(): {
   filters: FilterState;
-  kqlPreview: string;
-  kqlForExecution: string;
+  basicKQL: string;          // debounced basic where clauses only ("messages\n| where …")
   hasActiveFilters: boolean;
-  setFilter: (key: keyof FilterState, value: string | number) => void;
+  setFilter: (key: keyof FilterState, value: string) => void;
   setAllFilters: (partial: Partial<FilterState>) => void;
   resetFilters: () => void;
 } {
@@ -109,15 +102,14 @@ export function useFilterBar(): {
     return () => { if (textTimer.current) clearTimeout(textTimer.current); };
   }, [filters.feedback_text_search]);
 
-  const kqlPreview = buildKQLFromFilters(filters);
+  // Debounced basic clauses — safe to use as auto-run trigger
+  const basicClauses = buildBasicClauses(filters, debouncedTextSearch);
+  const basicKQL =
+    basicClauses.length === 0
+      ? 'messages'
+      : `messages\n${basicClauses.map(c => `| ${c}`).join('\n')}`;
 
-  const effectiveFilters: FilterState = {
-    ...filters,
-    feedback_text_search: debouncedTextSearch,
-  };
-  const kqlForExecution = buildKQLFromFilters(effectiveFilters);
-
-  const setFilter = useCallback((key: keyof FilterState, value: string | number) => {
+  const setFilter = useCallback((key: keyof FilterState, value: string) => {
     setFilters(prev => {
       const next = { ...prev, [key]: value };
       if (key === 'exact_rating' && value !== '') {
@@ -131,11 +123,9 @@ export function useFilterBar(): {
     });
   }, []);
 
-  // Set all filters at once (used when parsing KQL back into filter state)
   const setAllFilters = useCallback((partial: Partial<FilterState>) => {
     const next = { ...EMPTY_FILTER_STATE, ...partial };
     setFilters(next);
-    // Immediately sync debounced text search to avoid a 400ms lag
     setDebouncedTextSearch(partial.feedback_text_search ?? '');
   }, []);
 
@@ -157,13 +147,5 @@ export function useFilterBar(): {
     filters.tool_call_name !== '' ||
     filters.has_feedback_text !== '';
 
-  return {
-    filters,
-    kqlPreview,
-    kqlForExecution,
-    hasActiveFilters,
-    setFilter,
-    setAllFilters,
-    resetFilters,
-  };
+  return { filters, basicKQL, hasActiveFilters, setFilter, setAllFilters, resetFilters };
 }


### PR DESCRIPTION
the Advanced Query Builder now owns clause state as typed row lists with IDs
Each clause section shows stacked deletable rows with trashcan icons
All three of the sections sync bidirectionally; changes in any section instantly
update the other two through parseKQLFull()
useAdvancedBuilder hook owns row state; buildAdvancedClauses() serializes
to KQL strings; setFromParsed() hydrates from parsed textarea
substitutes order by summarize alias when feedback_submitted_at
is invalid after summarize, preventing unknown field errors
Each DashboardSection now has its own Clear button that resets all three sections simultaneously