### PR TITLE
feat(chat): non-PDF text citation modal + PDF citation slide-out

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -290,6 +290,13 @@ CONTEXT_MAX_SNIPPETS_PER_DOC=3
 # Optional: shorter keys in vector_search tool JSON (r,i,d,c,n,x,u,ty). Default off.
 TOOL_SEARCH_COMPACT_PAYLOAD=0
 
+# Crawl-time PDF capture: render each crawled page to PDF and attach a merged PDF
+# so the citation modal can highlight on the page layout. Default off — capture is
+# expensive (Selenium + CDP printToPDF per URL). Enabling at runtime ALSO requires
+# building the web image with chromium: pass the same flag as a build arg
+# (compose wires CRAWL_CAPTURE_PDF into the Dockerfile.prod build automatically).
+CRAWL_CAPTURE_PDF=0
+
 # Rollout profiles (see docs/superpowers/plans/2026-03-24-context-trimming-rollout-checklist.md):
 # Profile A baseline: CONTEXT_PACKER_ENABLED=0
 # Profile B smart packer: CONTEXT_PACKER_ENABLED=1

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env*
 .env.multimodal
 .venv
 env/

--- a/aquillm/apps/documents/migrations/0002_rawtextdocument_rendered_pdf.py
+++ b/aquillm/apps/documents/migrations/0002_rawtextdocument_rendered_pdf.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('apps_documents', '0001_initial_from_aquillm'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='rawtextdocument',
+            name='rendered_pdf',
+            field=models.FileField(blank=True, null=True, upload_to='crawled_pdfs/'),
+        ),
+    ]

--- a/aquillm/apps/documents/models/document_types/raw_text.py
+++ b/aquillm/apps/documents/models/document_types/raw_text.py
@@ -5,6 +5,9 @@ from ..document import Document
 
 class RawTextDocument(Document):
     source_url = models.URLField(max_length=2000, null=True, blank=True)
+    # Populated by the web crawler when each visited URL is captured as a PDF
+    # so the citation modal can reuse the PDF highlight UX for web content.
+    rendered_pdf = models.FileField(upload_to='crawled_pdfs/', null=True, blank=True)
 
     class Meta:
         app_label = 'apps_documents'

--- a/aquillm/apps/documents/services/citation_narrow.py
+++ b/aquillm/apps/documents/services/citation_narrow.py
@@ -1,0 +1,82 @@
+"""
+Narrow a citation: ask the project's configured LLM to extract the verbatim
+quote from a chunk that most directly supports a claim in an assistant
+message. The result is fed to the React PDF-citation modal's fuzzy locator
+to tighten the in-PDF highlight from "whole chunk" to "the relevant span".
+
+Same one-shot pattern as conversation auto-titling
+(apps/chat/models/conversation.py:set_name) — reuse `apps.llm_interface`.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import structlog
+from asgiref.sync import async_to_sync
+from django.apps import apps
+
+logger = structlog.stdlib.get_logger(__name__)
+
+
+SYSTEM_PROMPT = (
+    "You help highlight the most relevant text inside a cited source.\n"
+    "Given an ASSISTANT MESSAGE that cites a SOURCE chunk, output the\n"
+    "verbatim text from the SOURCE that most directly supports the claim.\n"
+    "\n"
+    "Rules:\n"
+    "- Output ONLY the quote text. No quotation marks around it, no\n"
+    "  commentary, no headers — just the raw text.\n"
+    "- Quote verbatim — character-for-character — what appears in SOURCE.\n"
+    "  Do not paraphrase, do not fix typos, do not normalise whitespace.\n"
+    "- Aim for 1-3 sentences (~30-300 characters).\n"
+    "- If no single passage is more relevant than the rest, or the chunk\n"
+    "  as a whole is the support, output an empty response.\n"
+)
+
+
+def _build_user_prompt(message_content: str, chunk_content: str) -> str:
+    return (
+        "ASSISTANT MESSAGE:\n"
+        f"{message_content}\n"
+        "\n"
+        "SOURCE:\n"
+        f"{chunk_content}\n"
+    )
+
+
+def narrow_citation(message_content: str, chunk_content: str) -> Optional[str]:
+    """Return a verbatim quote from `chunk_content` that supports the
+    assistant claim, or None on any failure / empty output.
+
+    Caller is expected to fall back to highlighting the full chunk when
+    None is returned.
+    """
+    if not message_content.strip() or not chunk_content.strip():
+        return None
+
+    llm_interface = apps.get_app_config('aquillm').llm_interface
+    llm_args = {
+        **llm_interface.base_args,
+        'max_tokens': 600,
+        'thinking_budget': 0,
+        'system': SYSTEM_PROMPT,
+        'messages': [{'role': 'user', 'content': _build_user_prompt(message_content, chunk_content)}],
+    }
+
+    @async_to_sync
+    async def call() -> str:
+        response = await llm_interface.get_message(**llm_args)
+        return response.text or ""
+
+    try:
+        quote = call().strip()
+    except Exception as exc:
+        logger.warning("Citation narrow LLM call failed: %s", exc)
+        return None
+
+    if not quote:
+        return None
+    # Strip a single layer of surrounding quotes if the model added them.
+    if len(quote) >= 2 and quote[0] == quote[-1] and quote[0] in ('"', "'"):
+        quote = quote[1:-1].strip()
+    return quote or None

--- a/aquillm/apps/documents/tasks/chunking.py
+++ b/aquillm/apps/documents/tasks/chunking.py
@@ -77,7 +77,7 @@ def create_chunks(self, doc_id: str):
             ]
             TextChunk.objects.bulk_create(new_chunks)
             doc.ingestion_complete = True
-            doc.save(dont_rechunk=True)
+            doc.save(dont_rechunk=True, update_fields=['ingestion_complete'])
             notify_ingest_monitor_complete(doc.id)
             return
 
@@ -156,14 +156,14 @@ def create_chunks(self, doc_id: str):
         send_progress(force=True)
         TextChunk.objects.bulk_create(chunks)
         doc.ingestion_complete = True
-        doc.save(dont_rechunk=True)
+        doc.save(dont_rechunk=True, update_fields=['ingestion_complete'])
         notify_ingest_monitor_complete(doc.id)
     except Exception as exc:
         logger.error("Error creating chunks for document %s: %s", doc.id, exc)
         self.update_state(state=FAILURE)
         doc.ingestion_complete = True
         doc.full_text += f"\n\nERROR DURING PROCESSING: {exc}"
-        doc.save(dont_rechunk=True)
+        doc.save(dont_rechunk=True, update_fields=['ingestion_complete', 'full_text'])
         raise
 
 

--- a/aquillm/apps/documents/urls.py
+++ b/aquillm/apps/documents/urls.py
@@ -10,6 +10,7 @@ app_name = 'documents'
 api_urlpatterns = [
     path("move/<uuid:doc_id>/", api_views.move_document, name="api_move_document"),
     path("delete/<uuid:doc_id>/", api_views.delete_document, name="api_delete_document"),
+    path("chunks/<int:chunk_id>/", api_views.chunk_detail, name="api_chunk_detail"),
 ]
 
 # Page URL patterns (to be included under /aquillm/)

--- a/aquillm/apps/documents/views/api.py
+++ b/aquillm/apps/documents/views/api.py
@@ -3,12 +3,14 @@ import json
 import structlog
 
 from django.contrib.auth.decorators import login_required
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.http import JsonResponse
 from django.views.decorators.http import require_http_methods
 
 from apps.collections.models import Collection
-from apps.documents.models import Document
+from apps.documents.models import Document, TextChunk
+from apps.documents.services.citation_narrow import narrow_citation
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -74,7 +76,102 @@ def move_document(request, doc_id):
     })
 
 
+@require_http_methods(["GET"])
+@login_required
+def chunk_detail(request, chunk_id):
+    """Return a chunk's text content plus its document's title and PDF availability.
+
+    Consumed by the React PDF citation modal to fuzzy-match the cited
+    passage against the PDF text layer.
+    """
+    chunk = TextChunk.objects.filter(pk=chunk_id).first()
+    if not chunk:
+        return JsonResponse({"error": "Chunk not found"}, status=404)
+
+    try:
+        doc = chunk.document
+    except ValidationError:
+        return JsonResponse({"error": "Chunk's document not found"}, status=404)
+
+    if not doc.collection.user_can_view(request.user):
+        return JsonResponse(
+            {"error": "You don't have access to the collection containing this chunk"},
+            status=403,
+        )
+
+    has_pdf = bool(getattr(doc, "pdf_file", None))
+
+    return JsonResponse({
+        "content": chunk.content,
+        "chunk_number": chunk.chunk_number,
+        "document": {
+            "id": str(doc.id),
+            "title": doc.title,
+            "has_pdf": has_pdf,
+        },
+    })
+
+
+CITATION_NARROW_CACHE_TTL = 60 * 60 * 24 * 7  # 7 days
+
+
+@require_http_methods(["POST"])
+@login_required
+def citation_narrow(request):
+    """Return an LLM-narrowed quote from a chunk that supports an assistant
+    message's claim. Used to tighten the in-PDF highlight from the whole
+    chunk to just the relevant span.
+
+    Body: {message_uuid: string, chunk_id: int}
+    Returns: {quote: string} — empty string when the LLM declines / fails
+    (caller falls back to highlighting the whole chunk).
+    """
+    try:
+        body = json.loads(request.body or b"{}")
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    message_uuid = body.get("message_uuid")
+    chunk_id = body.get("chunk_id")
+    if not message_uuid or not chunk_id:
+        return JsonResponse(
+            {"error": "message_uuid and chunk_id required"}, status=400,
+        )
+
+    from apps.chat.models import Message
+
+    message = Message.objects.filter(message_uuid=message_uuid).select_related("conversation").first()
+    if not message:
+        return JsonResponse({"error": "Message not found"}, status=404)
+    if message.conversation.owner_id != request.user.id:
+        return JsonResponse({"error": "Forbidden"}, status=403)
+
+    try:
+        chunk = TextChunk.objects.filter(pk=int(chunk_id)).first()
+    except (TypeError, ValueError):
+        return JsonResponse({"error": "Invalid chunk_id"}, status=400)
+    if not chunk:
+        return JsonResponse({"error": "Chunk not found"}, status=404)
+    try:
+        doc = chunk.document
+    except ValidationError:
+        return JsonResponse({"error": "Chunk's document not found"}, status=404)
+    if not doc.collection.user_can_view(request.user):
+        return JsonResponse({"error": "Forbidden"}, status=403)
+
+    cache_key = f"citation_narrow:{message_uuid}:{chunk.pk}"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return JsonResponse({"quote": cached, "cached": True})
+
+    quote = narrow_citation(message.content, chunk.content) or ""
+    cache.set(cache_key, quote, CITATION_NARROW_CACHE_TTL)
+    return JsonResponse({"quote": quote, "cached": False})
+
+
 __all__ = [
+    'chunk_detail',
+    'citation_narrow',
     'delete_document',
     'move_document',
 ]

--- a/aquillm/apps/documents/views/api.py
+++ b/aquillm/apps/documents/views/api.py
@@ -76,13 +76,18 @@ def move_document(request, doc_id):
     })
 
 
+FULL_TEXT_WINDOW_THRESHOLD = 500_000
+FULL_TEXT_WINDOW_PADDING = 5_000
+
+
 @require_http_methods(["GET"])
 @login_required
 def chunk_detail(request, chunk_id):
-    """Return a chunk's text content plus its document's title and PDF availability.
+    """Return a chunk plus enough document context for the citation modal.
 
-    Consumed by the React PDF citation modal to fuzzy-match the cited
-    passage against the PDF text layer.
+    The modal branches on `document.has_pdf`: when true the React side fuzzy-
+    matches the chunk into the PDF text layer; when false it renders
+    `document.full_text` with the chunk highlighted via offsets.
     """
     chunk = TextChunk.objects.filter(pk=chunk_id).first()
     if not chunk:
@@ -99,15 +104,33 @@ def chunk_detail(request, chunk_id):
             status=403,
         )
 
-    has_pdf = bool(getattr(doc, "pdf_file", None))
+    has_pdf = bool(
+        getattr(doc, "pdf_file", None) or getattr(doc, "rendered_pdf", None)
+    )
+
+    full_text = doc.full_text or ""
+    text_offset = 0
+    # Window very long docs around the chunk so the response stays bounded.
+    if len(full_text) > FULL_TEXT_WINDOW_THRESHOLD:
+        window_start = max(0, chunk.start_position - FULL_TEXT_WINDOW_PADDING)
+        window_end = min(len(full_text), chunk.end_position + FULL_TEXT_WINDOW_PADDING)
+        full_text = full_text[window_start:window_end]
+        text_offset = window_start
 
     return JsonResponse({
         "content": chunk.content,
         "chunk_number": chunk.chunk_number,
+        "start_position": chunk.start_position,
+        "end_position": chunk.end_position,
+        "start_time": chunk.start_time,
         "document": {
             "id": str(doc.id),
             "title": doc.title,
+            "type": doc.__class__.__name__,
             "has_pdf": has_pdf,
+            "source_url": getattr(doc, "source_url", None),
+            "full_text": full_text,
+            "text_offset": text_offset,
         },
     })
 

--- a/aquillm/apps/documents/views/pages.py
+++ b/aquillm/apps/documents/views/pages.py
@@ -30,13 +30,16 @@ def get_doc(request, doc_id):
 @require_http_methods(['GET'])
 @login_required
 def pdf(request, doc_id):
-    """Serve the PDF file for a document."""
+    """Serve the PDF file for a document.
+
+    PDFDocument uses `pdf_file`; TeXDocument uses `pdf_file` when compiled;
+    RawTextDocument uses `rendered_pdf` populated by the web crawler.
+    """
     doc = get_doc(request, doc_id)
-    if doc.pdf_file:
-        response = HttpResponse(doc.pdf_file, content_type='application/pdf')
-        return response
-    else:
-        raise Http404("Requested document does not have an associated PDF")
+    pdf_field = getattr(doc, 'pdf_file', None) or getattr(doc, 'rendered_pdf', None)
+    if pdf_field:
+        return HttpResponse(pdf_field, content_type='application/pdf')
+    raise Http404("Requested document does not have an associated PDF")
 
 
 @require_http_methods(['GET'])

--- a/aquillm/aquillm/api_views.py
+++ b/aquillm/aquillm/api_views.py
@@ -23,6 +23,8 @@ from apps.collections.views.api import (
 
 # Re-export document views
 from apps.documents.views.api import (
+    chunk_detail,
+    citation_narrow,
     delete_document,
     move_document,
 )
@@ -77,6 +79,8 @@ urlpatterns = [
     path("ingestion/monitor/", ingestion_monitor, name="api_ingestion_monitor"),
     path("documents/move/<uuid:doc_id>/", move_document, name="api_move_document"),
     path("documents/delete/<uuid:doc_id>/", delete_document, name="api_delete_document"),
+    path("chunks/<int:chunk_id>/", chunk_detail, name="api_chunk_detail"),
+    path("citations/narrow/", citation_narrow, name="api_citation_narrow"),
     path("users/search/", search_users, name="api_search_users"),
     path("whitelisted_email/<str:email>/", whitelisted_email, name="api_whitelist_email"),
     path("whitelisted_emails/", whitelisted_emails, name="api_whitelist_emails"),

--- a/aquillm/aquillm/context_processors.py
+++ b/aquillm/aquillm/context_processors.py
@@ -1,6 +1,7 @@
 """Template context processors: navigation, URLs exposed to the client, theme."""
 from __future__ import annotations
 
+import os
 import structlog
 from pathlib import Path
 from typing import Any
@@ -59,6 +60,8 @@ _API_URL_SPECS: list[tuple[str, str, dict[str, Any] | None]] = [
     ("api_ingest_uploads_status", "api_ingest_uploads_status", {"batch_id": 0}),
     ("api-user-settings", "api-user-settings", None),
     ("api_conversation_file", "api_conversation_file", {"convo_file_id": 0}),
+    ("api_chunk_detail", "api_chunk_detail", {"chunk_id": 0}),
+    ("api_citation_narrow", "api_citation_narrow", None),
     ("api_ingest_webpage", "api_ingest_webpage", None),
     # Page-backed ingest (not under /api/ but consumed like an API URL by the React app)
     ("api_ingest_handwritten_notes", "ingest_handwritten_notes", None),
@@ -140,6 +143,25 @@ def theme_settings(request):
 
 def app_version(request):
     return {"app_version": APP_VERSION}
+
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _env_bool(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def app_flags(request):
+    """Boolean feature flags exposed to the React app as window.appFlags."""
+    return {
+        "app_flags": {
+            # When truthy, the chat eagerly LLM-narrows every citation in
+            # newly arrived assistant messages so the cache is warm by the
+            # time the user clicks. See apps/documents/services/citation_narrow.py.
+            "eagerCitationNarrow": _env_bool("CITATION_NARROW_EAGER"),
+        },
+    }
 
 
 def react_bundle_version(request):

--- a/aquillm/aquillm/crawler_tasks.py
+++ b/aquillm/aquillm/crawler_tasks.py
@@ -1,3 +1,5 @@
+import base64
+import io
 import structlog
 import requests
 from urllib.parse import urlparse, urljoin
@@ -5,8 +7,11 @@ from bs4 import BeautifulSoup
 from celery import shared_task
 from celery.states import state, STARTED, SUCCESS, FAILURE
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.files.base import ContentFile
 from django.db import DatabaseError
 from django.contrib.auth import get_user_model
+
+import fitz  # PyMuPDF — used to merge per-URL PDFs into a single document.
 
 # Channels imports for WebSocket communication
 from channels.layers import get_channel_layer
@@ -31,6 +36,82 @@ logger = structlog.stdlib.get_logger(__name__)
 # Constants
 MIN_TEXT_LENGTH = 50 # Minimum characters to consider extraction successful
 SELENIUM_WAIT_TIME = 10 # Seconds to wait for dynamic content in Selenium
+MERGED_PDF_SIZE_CAP = 50 * 1024 * 1024 # 50MB cap on the merged crawl PDF
+
+
+def _init_selenium_driver():
+    """Create a headless Chrome driver suitable for both text extraction and PDF capture.
+
+    Uses the apt-installed Chromium + chromedriver when available (the path
+    the worker container takes); falls back to webdriver-manager's download
+    for local-dev / non-container environments.
+    """
+    import os
+    chrome_options = ChromeOptions()
+    chrome_options.add_argument("--headless=new")
+    chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--disable-dev-shm-usage")
+
+    chromium_bin = "/usr/bin/chromium"
+    chromedriver_bin = "/usr/bin/chromedriver"
+    if os.path.exists(chromium_bin) and os.path.exists(chromedriver_bin):
+        chrome_options.binary_location = chromium_bin
+        service = ChromeService(executable_path=chromedriver_bin)
+    else:
+        service = ChromeService(ChromeDriverManager().install())
+
+    driver = webdriver.Chrome(service=service, options=chrome_options)
+    driver.implicitly_wait(SELENIUM_WAIT_TIME)
+    return driver
+
+
+def _capture_page_pdf(driver, url, already_loaded):
+    """Return PDF bytes for `url`, or None on failure. Loads the page if needed."""
+    try:
+        if not already_loaded:
+            driver.get(url)
+        result = driver.execute_cdp_cmd(
+            "Page.printToPDF",
+            {"printBackground": True, "preferCSSPageSize": True},
+        )
+        data = result.get("data")
+        if not data:
+            return None
+        return base64.b64decode(data)
+    except Exception as e:
+        logger.warning(f"Page.printToPDF failed for {url}: {e}", exc_info=False)
+        return None
+
+
+def _merge_pdfs(pdf_bytes_list):
+    """Merge per-URL PDF byte blobs into one, capped at MERGED_PDF_SIZE_CAP. Returns bytes or None."""
+    if not pdf_bytes_list:
+        return None
+    try:
+        merged = fitz.open()
+        for blob in pdf_bytes_list:
+            try:
+                src = fitz.open(stream=blob, filetype="pdf")
+                merged.insert_pdf(src)
+                src.close()
+            except Exception as e:
+                logger.warning(f"Skipping bad per-URL PDF during merge: {e}", exc_info=False)
+        if merged.page_count == 0:
+            merged.close()
+            return None
+        out = merged.tobytes()
+        merged.close()
+        if len(out) > MERGED_PDF_SIZE_CAP and len(pdf_bytes_list) > 1:
+            logger.warning(
+                f"Merged crawl PDF size {len(out)} exceeds cap {MERGED_PDF_SIZE_CAP}; "
+                f"falling back to first-URL PDF only."
+            )
+            # Fall back to just the first URL's PDF.
+            return pdf_bytes_list[0] if len(pdf_bytes_list[0]) <= MERGED_PDF_SIZE_CAP else None
+        return out
+    except Exception as e:
+        logger.warning(f"Failed to merge crawl PDFs: {e}", exc_info=False)
+        return None
 
 def is_same_domain(base_url, link_url):
     """Checks if a link URL belongs to the same domain as the base URL."""
@@ -100,6 +181,7 @@ def crawl_and_ingest_webpage(self, initial_url: str, collection_id: int, user_id
     visited_urls = set()
     urls_to_visit = [(initial_url, 0)] # (url, depth)
     all_text_content = []
+    per_url_pdfs = [] # PDF bytes for each successfully captured URL, in crawl order
     page_title = initial_url # Fallback title
     processed_count = 0
     total_urls_found = 1 # Start with the initial URL
@@ -124,6 +206,7 @@ def crawl_and_ingest_webpage(self, initial_url: str, collection_id: int, user_id
             extracted_text = None
             html_content_for_links = None
             new_links_found = set()
+            selenium_loaded_this_url = False
 
             # --- Attempt 1: Trafilatura ---
             try:
@@ -154,17 +237,11 @@ def crawl_and_ingest_webpage(self, initial_url: str, collection_id: int, user_id
                 logger.info(f"[Task {task_id}] Trafilatura failed or insufficient. Attempting Selenium fallback for: {current_url}")
                 try:
                     if selenium_driver is None: # Initialize driver only if needed
-                        chrome_options = ChromeOptions()
-                        chrome_options.add_argument("--headless") # Run headless
-                        chrome_options.add_argument("--no-sandbox")
-                        chrome_options.add_argument("--disable-dev-shm-usage")
-                        # Use webdriver-manager to automatically handle driver download/updates
-                        service = ChromeService(ChromeDriverManager().install())
-                        selenium_driver = webdriver.Chrome(service=service, options=chrome_options)
-                        selenium_driver.implicitly_wait(SELENIUM_WAIT_TIME) # Implicit wait
+                        selenium_driver = _init_selenium_driver()
                         logger.info(f"[Task {task_id}] Selenium WebDriver initialized.")
 
                     selenium_driver.get(current_url)
+                    selenium_loaded_this_url = True
                     # Consider adding explicit waits here if needed for specific dynamic content
                     # WebDriverWait(selenium_driver, SELENIUM_WAIT_TIME).until(...)
 
@@ -211,6 +288,19 @@ def crawl_and_ingest_webpage(self, initial_url: str, collection_id: int, user_id
             # --- Process extracted text and find links ---
             if extracted_text:
                 all_text_content.append(f"\n\n--- Source: {current_url} ---\n\n{extracted_text}")
+
+                # Capture a PDF rendering of the page so the citation modal can
+                # highlight the cited passage on the original page layout.
+                try:
+                    if selenium_driver is None:
+                        selenium_driver = _init_selenium_driver()
+                        logger.info(f"[Task {task_id}] Selenium WebDriver initialized for PDF capture.")
+                    pdf_bytes = _capture_page_pdf(selenium_driver, current_url, selenium_loaded_this_url)
+                    if pdf_bytes:
+                        per_url_pdfs.append(pdf_bytes)
+                except Exception as e:
+                    logger.warning(f"[Task {task_id}] PDF capture failed for {current_url}: {e}", exc_info=False)
+
                 if current_depth < max_depth and html_content_for_links:
                     try:
                         found_links = find_links(html_content_for_links, current_url)
@@ -246,6 +336,31 @@ def crawl_and_ingest_webpage(self, initial_url: str, collection_id: int, user_id
                 doc_id_str = str(doc.id)
                 doc_title = doc.title
                 logger.info(f"[Task {task_id}] Successfully saved RawTextDocument {doc_id_str} for initial URL {initial_url}")
+
+                # Attach merged PDF rendering. Failure is non-fatal — the citation
+                # modal falls back to a text-highlight view when rendered_pdf is absent.
+                try:
+                    merged_pdf_bytes = _merge_pdfs(per_url_pdfs)
+                    if merged_pdf_bytes:
+                        # save=False so we can control the subsequent .save() and scope it
+                        # to update_fields=['rendered_pdf'] — the chunking task runs
+                        # concurrently and would otherwise clobber this column on its own
+                        # save from stale in-memory state.
+                        doc.rendered_pdf.save(
+                            f"{doc.id}.pdf",
+                            ContentFile(merged_pdf_bytes),
+                            save=False,
+                        )
+                        doc.save(dont_rechunk=True, update_fields=['rendered_pdf'])
+                        logger.info(
+                            f"[Task {task_id}] Saved rendered_pdf for {doc_id_str} "
+                            f"({len(merged_pdf_bytes)} bytes, {len(per_url_pdfs)} pages merged)."
+                        )
+                except Exception as e:
+                    logger.warning(
+                        f"[Task {task_id}] Failed to attach rendered_pdf for {doc_id_str}: {e}",
+                        exc_info=False,
+                    )
                 self.update_state(state=SUCCESS, meta={'document_id': doc_id_str, 'title': doc_title, 'progress': 100, 'task_id': task_id})
                 send_crawl_status(user_id, task_id, 'crawl.success', {'document_id': doc_id_str, 'title': doc_title, 'message': 'Crawl and save successful.'})
                 return {'document_id': doc_id_str, 'title': doc_title}

--- a/aquillm/aquillm/crawler_tasks.py
+++ b/aquillm/aquillm/crawler_tasks.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse, urljoin
 from bs4 import BeautifulSoup
 from celery import shared_task
 from celery.states import state, STARTED, SUCCESS, FAILURE
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.files.base import ContentFile
 from django.db import DatabaseError
@@ -291,15 +292,18 @@ def crawl_and_ingest_webpage(self, initial_url: str, collection_id: int, user_id
 
                 # Capture a PDF rendering of the page so the citation modal can
                 # highlight the cited passage on the original page layout.
-                try:
-                    if selenium_driver is None:
-                        selenium_driver = _init_selenium_driver()
-                        logger.info(f"[Task {task_id}] Selenium WebDriver initialized for PDF capture.")
-                    pdf_bytes = _capture_page_pdf(selenium_driver, current_url, selenium_loaded_this_url)
-                    if pdf_bytes:
-                        per_url_pdfs.append(pdf_bytes)
-                except Exception as e:
-                    logger.warning(f"[Task {task_id}] PDF capture failed for {current_url}: {e}", exc_info=False)
+                # Gated behind CRAWL_CAPTURE_PDF — capture is expensive (Selenium
+                # + CDP printToPDF per URL) and off by default.
+                if settings.CRAWL_CAPTURE_PDF:
+                    try:
+                        if selenium_driver is None:
+                            selenium_driver = _init_selenium_driver()
+                            logger.info(f"[Task {task_id}] Selenium WebDriver initialized for PDF capture.")
+                        pdf_bytes = _capture_page_pdf(selenium_driver, current_url, selenium_loaded_this_url)
+                        if pdf_bytes:
+                            per_url_pdfs.append(pdf_bytes)
+                    except Exception as e:
+                        logger.warning(f"[Task {task_id}] PDF capture failed for {current_url}: {e}", exc_info=False)
 
                 if current_depth < max_depth and html_content_for_links:
                     try:

--- a/aquillm/aquillm/settings.py
+++ b/aquillm/aquillm/settings.py
@@ -81,6 +81,11 @@ CONTEXT_BUDGET_RETRIEVAL_TOKENS = env_int("CONTEXT_BUDGET_RETRIEVAL_TOKENS", 350
 CONTEXT_PIN_LAST_TURNS = env_int("CONTEXT_PIN_LAST_TURNS", 2)
 CONTEXT_MAX_SNIPPETS_PER_DOC = env_int("CONTEXT_MAX_SNIPPETS_PER_DOC", 3)
 
+# Crawl-time PDF capture: render each crawled page to PDF and attach a merged
+# PDF to the document so the citation modal can highlight on the page layout.
+# Off by default — capture is expensive (Selenium + CDP printToPDF per URL).
+CRAWL_CAPTURE_PDF = env_bool("CRAWL_CAPTURE_PDF", False)
+
 # Pluggable LLM skills (`lib.skills`); off by default. See `mcp-skills-agents-runtime.md`.
 SKILLS_ENABLED = env_bool("AQUILLM_SKILLS_ENABLED", False)
 AQUILLM_SKILLS_EXTRA_MODULES = env_csv("AQUILLM_SKILLS_EXTRA_MODULES")

--- a/aquillm/aquillm/settings.py
+++ b/aquillm/aquillm/settings.py
@@ -207,6 +207,7 @@ TEMPLATES = [
                 "aquillm.context_processors.react_bundle_version",
                 "aquillm.context_processors.theme_settings",
                 "aquillm.context_processors.app_version",
+                "aquillm.context_processors.app_flags",
             ],
         },
     },

--- a/aquillm/templates/aquillm/base.html
+++ b/aquillm/templates/aquillm/base.html
@@ -726,9 +726,11 @@
 {% if user.is_authenticated%}
     {{ api_urls|json_script:"api_urls" }}
     {{ page_urls|json_script:"page_urls" }}
+    {{ app_flags|json_script:"app_flags" }}
     <script type="text/javascript">
         window.apiUrls = JSON.parse(document.getElementById('api_urls').textContent);
         window.pageUrls = JSON.parse(document.getElementById('page_urls').textContent);
+        window.appFlags = JSON.parse(document.getElementById('app_flags').textContent);
     </script>
 {% endif %}
 

--- a/deploy/compose/development.yml
+++ b/deploy/compose/development.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: ../..
       dockerfile: deploy/docker/web/Dockerfile.prod
+      args:
+        CRAWL_CAPTURE_PDF: ${CRAWL_CAPTURE_PDF:-false}
 
     restart: unless-stopped
     env_file:
@@ -61,6 +63,8 @@ services:
     build:
       context: ../..
       dockerfile: deploy/docker/web/Dockerfile.prod
+      args:
+        CRAWL_CAPTURE_PDF: ${CRAWL_CAPTURE_PDF:-false}
     restart: unless-stopped
     env_file:
       - ../../.env
@@ -105,6 +109,8 @@ services:
     build:
       context: ../..
       dockerfile: deploy/docker/web/Dockerfile.prod
+      args:
+        CRAWL_CAPTURE_PDF: ${CRAWL_CAPTURE_PDF:-false}
     restart: unless-stopped
     env_file:
       - ../../.env

--- a/deploy/compose/no_gpu_dev.yml
+++ b/deploy/compose/no_gpu_dev.yml
@@ -57,6 +57,8 @@ services:
     build:
       context: ../..
       dockerfile: deploy/docker/web/Dockerfile.prod
+      args:
+        CRAWL_CAPTURE_PDF: ${CRAWL_CAPTURE_PDF:-false}
     ports:
       - "${PORT:-8080}:${PORT:-8080}"
     restart: unless-stopped
@@ -86,6 +88,8 @@ services:
     build:
       context: ../..
       dockerfile: deploy/docker/web/Dockerfile.prod
+      args:
+        CRAWL_CAPTURE_PDF: ${CRAWL_CAPTURE_PDF:-false}
     restart: unless-stopped
     env_file:
       - ../../.env

--- a/deploy/compose/production.yml
+++ b/deploy/compose/production.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: ../..
       dockerfile: deploy/docker/web/Dockerfile.prod
+      args:
+        CRAWL_CAPTURE_PDF: ${CRAWL_CAPTURE_PDF:-false}
 
     restart: unless-stopped
     env_file:
@@ -54,6 +56,8 @@ services:
     build:
       context: ../..
       dockerfile: deploy/docker/web/Dockerfile.prod
+      args:
+        CRAWL_CAPTURE_PDF: ${CRAWL_CAPTURE_PDF:-false}
     restart: unless-stopped
     env_file:
       - ../../.env
@@ -98,6 +102,8 @@ services:
     build:
       context: ../..
       dockerfile: deploy/docker/web/Dockerfile.prod
+      args:
+        CRAWL_CAPTURE_PDF: ${CRAWL_CAPTURE_PDF:-false}
     restart: unless-stopped
     env_file:
       - ../../.env

--- a/deploy/docker/web/Dockerfile.prod
+++ b/deploy/docker/web/Dockerfile.prod
@@ -10,7 +10,8 @@ COPY pyproject.toml uv.lock ./
 RUN UV_CONCURRENT_DOWNLOADS=1 UV_CONCURRENT_INSTALLS=1 uv sync --frozen --no-dev --no-cache
 RUN uv pip install --python /opt/venv/bin/python --no-cache-dir "mem0ai[graph]" langchain-memgraph rank-bm25
 RUN apt update && apt install -y curl nodejs npm tesseract-ocr \
-    libreoffice-writer-nogui libreoffice-calc-nogui libreoffice-impress-nogui
+    libreoffice-writer-nogui libreoffice-calc-nogui libreoffice-impress-nogui \
+    chromium chromium-driver fonts-liberation
 COPY . .
 
 

--- a/deploy/docker/web/Dockerfile.prod
+++ b/deploy/docker/web/Dockerfile.prod
@@ -10,8 +10,15 @@ COPY pyproject.toml uv.lock ./
 RUN UV_CONCURRENT_DOWNLOADS=1 UV_CONCURRENT_INSTALLS=1 uv sync --frozen --no-dev --no-cache
 RUN uv pip install --python /opt/venv/bin/python --no-cache-dir "mem0ai[graph]" langchain-memgraph rank-bm25
 RUN apt update && apt install -y curl nodejs npm tesseract-ocr \
-    libreoffice-writer-nogui libreoffice-calc-nogui libreoffice-impress-nogui \
-    chromium chromium-driver fonts-liberation
+    libreoffice-writer-nogui libreoffice-calc-nogui libreoffice-impress-nogui
+
+# Chromium is only needed for crawl-time PDF capture (CRAWL_CAPTURE_PDF). It is
+# heavy (~400MB with deps), so install it only when that feature is built in.
+# Pass --build-arg CRAWL_CAPTURE_PDF=true (compose wires this from the env var).
+ARG CRAWL_CAPTURE_PDF=false
+RUN if [ "$CRAWL_CAPTURE_PDF" = "true" ] || [ "$CRAWL_CAPTURE_PDF" = "1" ]; then \
+        apt update && apt install -y chromium chromium-driver fonts-liberation; \
+    fi
 COPY . .
 
 

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -15,6 +15,7 @@
         "react-circular-progressbar": "^2.2.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
+        "react-pdf": "^10.4.1",
         "react-syntax-highlighter": "^15.6.1",
         "rehype-katex": "^7.0.1",
         "rehype-raw": "^7.0.0",
@@ -789,6 +790,271 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1534,6 +1800,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -2444,8 +2719,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2542,6 +2816,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lowlight": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
@@ -2570,6 +2856,24 @@
       "integrity": "sha512-NJzvVu1HwFVeZ+Gwq2q00KygM1aBhy/ZrhY9FsAgJtpB+E4R7uxRk9M2iKvHa6/vNxZydIB59htha4c2vvwvVg==",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/make-cancellable-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-2.0.0.tgz",
+      "integrity": "sha512-3SEQqTpV9oqVsIWqAcmDuaNeo7yBO3tqPtqGRcKkEo0lrzD3wqbKG9mkxO65KoOgXqj+zH2phJ2LiAsdzlogSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-cancellable-promise?sponsor=1"
+      }
+    },
+    "node_modules/make-event-props": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-2.0.0.tgz",
+      "integrity": "sha512-G/hncXrl4Qt7mauJEXSg3AcdYzmpkIITTNl5I+rH9sog5Yw0kK6vseJjCaPfOXqOqQuPUP89Rkhfz5kPS8ijtw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
       }
     },
     "node_modules/markdown-table": {
@@ -2852,6 +3156,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/merge-refs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-2.0.0.tgz",
+      "integrity": "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/merge-refs?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/merge2": {
@@ -3607,6 +3928,18 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3919,6 +4252,35 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-pdf": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-10.4.1.tgz",
+      "integrity": "sha512-kS/35staVCBqS29verTQJQZXw7RfsRCPO3fdJoW1KXylcv7A9dw6DZ3vJXC2w+bIBgLw5FN4pOFvKSQtkQhPfA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "dequal": "^2.0.3",
+        "make-cancellable-promise": "^2.0.0",
+        "make-event-props": "^2.0.0",
+        "merge-refs": "^2.0.0",
+        "pdfjs-dist": "5.4.296",
+        "tiny-invariant": "^1.0.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -4561,6 +4923,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4862,6 +5230,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/web-namespaces": {

--- a/react/package.json
+++ b/react/package.json
@@ -20,6 +20,7 @@
     "react-circular-progressbar": "^2.2.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
+    "react-pdf": "^10.4.1",
     "react-syntax-highlighter": "^15.6.1",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",

--- a/react/src/features/chat/components/ChatShell.tsx
+++ b/react/src/features/chat/components/ChatShell.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import Chat from './Chat';
+import CitationModalProvider, { CitationPanelSlot } from './CitationModalProvider';
 
 const ChatShell: React.FC<{ convoId: string; contextLimit?: number }> = (props) => (
-  <div className="h-full flex flex-col">
-    <Chat {...props} />
-  </div>
+  <CitationModalProvider>
+    <div className="h-full flex">
+      <div className="flex-1 min-w-0 flex flex-col">
+        <Chat {...props} />
+      </div>
+      <CitationPanelSlot />
+    </div>
+  </CitationModalProvider>
 );
 
 export default ChatShell;

--- a/react/src/features/chat/components/CitationModalProvider.tsx
+++ b/react/src/features/chat/components/CitationModalProvider.tsx
@@ -1,4 +1,6 @@
-import React, { createContext, lazy, Suspense, useCallback, useContext, useState } from 'react';
+import React, { createContext, lazy, Suspense, useCallback, useContext, useEffect, useState } from 'react';
+import formatUrl from '../../../utils/formatUrl';
+import type { CitationChunkDetail } from './citationTypes';
 
 // Lazy-loaded to keep react-pdf / pdfjs-dist (which use `import.meta`) out
 // of the main bundle. main.js is loaded as a classic <script>, so any
@@ -7,6 +9,7 @@ import React, { createContext, lazy, Suspense, useCallback, useContext, useState
 // dynamic import becomes synchronous in the bundle, but the lazy wrapper
 // is harmless and preserves code-splitting if we ever switch back to ESM.
 const PDFCitationModal = lazy(() => import('./PDFCitationModal'));
+const TextCitationModal = lazy(() => import('./TextCitationModal'));
 
 /** Width of the slide-out citation panel. The outer container animates
  * between 0 and this width; the inner content stays fixed-width so it
@@ -54,6 +57,79 @@ export const CitationModalProvider: React.FC<{ children: React.ReactNode }> = ({
   );
 };
 
+/** Fetches chunk metadata and dispatches to the PDF or text modal. The
+ *  fetch happens here (not inside the modals) so the dispatch decision
+ *  is made before either heavy component mounts. */
+const CitationDispatcher: React.FC<{ target: CitationTarget; onClose: () => void }> = ({
+  target,
+  onClose,
+}) => {
+  const [chunk, setChunk] = useState<CitationChunkDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setChunk(null);
+    setError(null);
+    let cancelled = false;
+    const apiPattern = window.apiUrls?.api_chunk_detail;
+    if (!apiPattern) {
+      setError('Chunk detail API not configured.');
+      return;
+    }
+    const url = formatUrl(apiPattern, { chunk_id: target.chunkId });
+    fetch(url, { credentials: 'include' })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((data: CitationChunkDetail) => {
+        if (!cancelled) setChunk(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err?.message || 'Failed to load chunk.');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [target.chunkId]);
+
+  if (error) {
+    // Hand off to the text modal which renders a friendly error state.
+    return (
+      <Suspense fallback={null}>
+        <TextCitationModal
+          docId={target.docId}
+          chunkId={target.chunkId}
+          messageUuid={target.messageUuid}
+          preloadedChunk={null}
+          onClose={onClose}
+        />
+      </Suspense>
+    );
+  }
+
+  if (!chunk) {
+    return (
+      <div className="bg-scheme-shade_3 h-full flex items-center justify-center text-text-low_contrast text-sm">
+        Loading citation…
+      </div>
+    );
+  }
+
+  const Modal = chunk.document.has_pdf ? PDFCitationModal : TextCitationModal;
+  return (
+    <Suspense fallback={null}>
+      <Modal
+        docId={target.docId}
+        chunkId={target.chunkId}
+        messageUuid={target.messageUuid}
+        preloadedChunk={chunk}
+        onClose={onClose}
+      />
+    </Suspense>
+  );
+};
+
 /**
  * Slide-out panel slot. Rendered as a sibling of the chat in ChatShell.
  * The outer container animates `width: 0 → CITATION_PANEL_WIDTH` with a
@@ -70,16 +146,7 @@ export const CitationPanelSlot: React.FC = () => {
       style={{ width: isOpen ? CITATION_PANEL_WIDTH : 0 }}
     >
       <div className="h-full" style={{ width: CITATION_PANEL_WIDTH }}>
-        {target && (
-          <Suspense fallback={null}>
-            <PDFCitationModal
-              docId={target.docId}
-              chunkId={target.chunkId}
-              messageUuid={target.messageUuid}
-              onClose={closeCitation}
-            />
-          </Suspense>
-        )}
+        {target && <CitationDispatcher target={target} onClose={closeCitation} />}
       </div>
     </div>
   );

--- a/react/src/features/chat/components/CitationModalProvider.tsx
+++ b/react/src/features/chat/components/CitationModalProvider.tsx
@@ -1,0 +1,88 @@
+import React, { createContext, lazy, Suspense, useCallback, useContext, useState } from 'react';
+
+// Lazy-loaded to keep react-pdf / pdfjs-dist (which use `import.meta`) out
+// of the main bundle. main.js is loaded as a classic <script>, so any
+// top-level `import.meta` would be a parse error and stop React from
+// mounting on every page. With Vite's IIFE + inlineDynamicImports the
+// dynamic import becomes synchronous in the bundle, but the lazy wrapper
+// is harmless and preserves code-splitting if we ever switch back to ESM.
+const PDFCitationModal = lazy(() => import('./PDFCitationModal'));
+
+/** Width of the slide-out citation panel. The outer container animates
+ * between 0 and this width; the inner content stays fixed-width so it
+ * doesn't reflow as the panel opens. */
+export const CITATION_PANEL_WIDTH = 640;
+
+interface CitationTarget {
+  docId: string;
+  chunkId: string;
+  /** Optional: assistant message UUID, used to enable LLM narrowing of the
+   * highlight. When omitted (e.g. citations clicked outside chat), the
+   * panel falls back to whole-chunk highlighting. */
+  messageUuid?: string;
+}
+
+interface CitationModalContextValue {
+  openCitation: (target: CitationTarget) => void;
+  closeCitation: () => void;
+  target: CitationTarget | null;
+  isOpen: boolean;
+}
+
+const CitationModalContext = createContext<CitationModalContextValue | null>(null);
+
+export function useCitationModal(): CitationModalContextValue {
+  const ctx = useContext(CitationModalContext);
+  if (!ctx) {
+    return { openCitation: () => {}, closeCitation: () => {}, target: null, isOpen: false };
+  }
+  return ctx;
+}
+
+export const CitationModalProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [target, setTarget] = useState<CitationTarget | null>(null);
+
+  const openCitation = useCallback((next: CitationTarget) => setTarget(next), []);
+  const closeCitation = useCallback(() => setTarget(null), []);
+
+  return (
+    <CitationModalContext.Provider
+      value={{ openCitation, closeCitation, target, isOpen: target !== null }}
+    >
+      {children}
+    </CitationModalContext.Provider>
+  );
+};
+
+/**
+ * Slide-out panel slot. Rendered as a sibling of the chat in ChatShell.
+ * The outer container animates `width: 0 → CITATION_PANEL_WIDTH` with a
+ * CSS transition; the inner content keeps its fixed width so the PDF
+ * viewer doesn't reflow during the slide.
+ */
+export const CitationPanelSlot: React.FC = () => {
+  const { target, closeCitation } = useCitationModal();
+  const isOpen = target !== null;
+  return (
+    <div
+      aria-hidden={!isOpen}
+      className="h-full flex-shrink-0 overflow-hidden transition-[width] duration-300 ease-out border-l border-border-mid_contrast"
+      style={{ width: isOpen ? CITATION_PANEL_WIDTH : 0 }}
+    >
+      <div className="h-full" style={{ width: CITATION_PANEL_WIDTH }}>
+        {target && (
+          <Suspense fallback={null}>
+            <PDFCitationModal
+              docId={target.docId}
+              chunkId={target.chunkId}
+              messageUuid={target.messageUuid}
+              onClose={closeCitation}
+            />
+          </Suspense>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CitationModalProvider;

--- a/react/src/features/chat/components/MessageBubble.tsx
+++ b/react/src/features/chat/components/MessageBubble.tsx
@@ -6,10 +6,12 @@ import rehypeRaw from 'rehype-raw';
 import rehypeKatex from 'rehype-katex';
 import 'katex/dist/katex.min.css';
 import formatUrl from '../../../utils/formatUrl';
-import { linkifyRagCitations } from '../../../utils/linkifyRagCitations';
+import { DOC_CHUNK_CITATION_RE, linkifyRagCitations } from '../../../utils/linkifyRagCitations';
 import { resolveSiteAbsoluteUrl } from '../../../utils/resolveSiteAbsoluteUrl';
 import { Collapsible, ToolResult, AquillmLogo, UserLogo } from '../../../shared/components';
 import { RatingButtons } from './RatingButtons';
+import { useCitationModal } from './CitationModalProvider';
+import { getCsrfCookie } from '../../../main';
 import type { Message } from '../types';
 
 interface MessageBubbleProps {
@@ -22,6 +24,64 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({ message, onRate, o
   const displayTime = new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
   const contentRef = useRef<HTMLDivElement>(null);
   const activeBtnRef = useRef<HTMLButtonElement | null>(null);
+  const { openCitation } = useCitationModal();
+  const messageUuid = message.message_uuid;
+  const eagerNarrowSeenRef = useRef<Set<string>>(new Set());
+
+  // Eager LLM-narrow every citation in newly arrived assistant messages
+  // when window.appFlags.eagerCitationNarrow is on. Fire-and-forget — the
+  // backend caches by (message_uuid, chunk_pk) so subsequent clicks open
+  // instantly. Per-bubble dedupe ref guards against re-firing on re-render
+  // (e.g. when streaming content updates).
+  useEffect(() => {
+    if (!messageUuid || message.role !== 'assistant') return;
+    if (!window.appFlags?.eagerCitationNarrow) return;
+    const apiUrl = window.apiUrls?.api_citation_narrow;
+    if (!apiUrl) return;
+    const content = message.content || '';
+    if (!content) return;
+    DOC_CHUNK_CITATION_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = DOC_CHUNK_CITATION_RE.exec(content))) {
+      const chunkId = match[2];
+      const key = `${messageUuid}:${chunkId}`;
+      if (eagerNarrowSeenRef.current.has(key)) continue;
+      eagerNarrowSeenRef.current.add(key);
+      fetch(apiUrl, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCsrfCookie(),
+        },
+        body: JSON.stringify({ message_uuid: messageUuid, chunk_id: Number(chunkId) }),
+      }).catch(() => {
+        // Swallow — best-effort prefetch. Click-time fetch will retry.
+      });
+    }
+  }, [messageUuid, message.role, message.content]);
+
+  // Intercept plain clicks on .rag-citation-link anchors and route them to
+  // the PDF citation modal. Modifier-clicks (ctrl/cmd/shift) and middle
+  // clicks fall through to the anchor's native "open in new tab".
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    const onClick = (e: MouseEvent) => {
+      if (e.defaultPrevented) return;
+      if (e.button !== 0) return; // middle/right click: native behaviour
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      const target = (e.target as Element | null)?.closest?.('.rag-citation-link');
+      if (!target) return;
+      const docId = target.getAttribute('data-doc-id');
+      const chunkId = target.getAttribute('data-chunk-id');
+      if (!docId || !chunkId) return;
+      e.preventDefault();
+      openCitation({ docId, chunkId, messageUuid });
+    };
+    el.addEventListener('click', onClick);
+    return () => el.removeEventListener('click', onClick);
+  }, [openCitation, messageUuid]);
 
   useEffect(() => {
     const el = contentRef.current;

--- a/react/src/features/chat/components/PDFCitationModal.tsx
+++ b/react/src/features/chat/components/PDFCitationModal.tsx
@@ -11,24 +11,19 @@ import {
   type PageHighlightRange,
 } from '../../../utils/pdfTextMatch';
 import { getCsrfCookie } from '../../../main';
+import type { CitationChunkDetail } from './citationTypes';
 
 configurePdfWorker();
 
-interface ChunkDetail {
-  content: string;
-  chunk_number: number;
-  document: {
-    id: string;
-    title: string;
-    has_pdf: boolean;
-  };
-}
+type ChunkDetail = CitationChunkDetail;
 
 interface PDFCitationModalProps {
   docId: string;
   chunkId: string;
   /** Assistant message UUID — enables LLM-narrowed highlight. */
   messageUuid?: string;
+  /** Optional chunk prefetched by the provider, skipping the initial fetch. */
+  preloadedChunk?: CitationChunkDetail | null;
   onClose: () => void;
 }
 
@@ -61,9 +56,10 @@ export const PDFCitationModal: React.FC<PDFCitationModalProps> = ({
   docId,
   chunkId,
   messageUuid,
+  preloadedChunk,
   onClose,
 }) => {
-  const [chunk, setChunk] = useState<ChunkDetail | null>(null);
+  const [chunk, setChunk] = useState<ChunkDetail | null>(preloadedChunk ?? null);
   const [chunkError, setChunkError] = useState<string | null>(null);
 
   // LLM-narrowed quote. When set, replaces chunk.content as the locator input.
@@ -96,7 +92,9 @@ export const PDFCitationModal: React.FC<PDFCitationModalProps> = ({
   }, [onClose]);
 
   // Fetch chunk metadata (content + document title + PDF availability).
+  // Skipped when the provider has already fetched it.
   useEffect(() => {
+    if (preloadedChunk) return;
     let cancelled = false;
     const apiPattern = window.apiUrls?.api_chunk_detail;
     if (!apiPattern) {
@@ -118,7 +116,7 @@ export const PDFCitationModal: React.FC<PDFCitationModalProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [chunkId]);
+  }, [chunkId, preloadedChunk]);
 
   // In parallel with the chunk fetch, ask the backend to LLM-narrow the
   // citation to the most relevant verbatim quote.

--- a/react/src/features/chat/components/PDFCitationModal.tsx
+++ b/react/src/features/chat/components/PDFCitationModal.tsx
@@ -1,0 +1,508 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Document, Page } from 'react-pdf';
+import type { PDFDocumentProxy, PageViewport } from 'pdfjs-dist';
+import { X, ExternalLink } from 'lucide-react';
+import 'react-pdf/dist/Page/AnnotationLayer.css';
+import 'react-pdf/dist/Page/TextLayer.css';
+import formatUrl from '../../../utils/formatUrl';
+import { configurePdfWorker } from '../../../utils/pdfWorker';
+import {
+  locateAcrossDocument,
+  type PageHighlightRange,
+} from '../../../utils/pdfTextMatch';
+import { getCsrfCookie } from '../../../main';
+
+configurePdfWorker();
+
+interface ChunkDetail {
+  content: string;
+  chunk_number: number;
+  document: {
+    id: string;
+    title: string;
+    has_pdf: boolean;
+  };
+}
+
+interface PDFCitationModalProps {
+  docId: string;
+  chunkId: string;
+  /** Assistant message UUID — enables LLM-narrowed highlight. */
+  messageUuid?: string;
+  onClose: () => void;
+}
+
+/** Each PDF text-layer item we need to compute a highlight rect. */
+interface PdfTextItem {
+  str: string;
+  /** PDF.js 2D affine matrix: [a, b, c, d, e, f]. (e, f) is the baseline. */
+  transform: number[];
+  /** Item width in PDF user units (pre-scale). */
+  width: number;
+}
+
+interface PageScan {
+  pageNumber: number;
+  items: PdfTextItem[];
+  /** Viewport at the rendered scale — used to convert PDF coords to pixels. */
+  viewport: PageViewport;
+}
+
+interface HighlightRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+const DATA_HIGHLIGHT_ATTR = 'data-citation-hit';
+
+export const PDFCitationModal: React.FC<PDFCitationModalProps> = ({
+  docId,
+  chunkId,
+  messageUuid,
+  onClose,
+}) => {
+  const [chunk, setChunk] = useState<ChunkDetail | null>(null);
+  const [chunkError, setChunkError] = useState<string | null>(null);
+
+  // LLM-narrowed quote. When set, replaces chunk.content as the locator input.
+  const [narrowQuote, setNarrowQuote] = useState<string | null>(null);
+  const [narrowState, setNarrowState] = useState<'idle' | 'pending' | 'tightened' | 'failed'>(
+    'idle',
+  );
+
+  const [pdfDoc, setPdfDoc] = useState<PDFDocumentProxy | null>(null);
+  const [numPages, setNumPages] = useState(0);
+  const [pageHighlights, setPageHighlights] = useState<Map<number, PageHighlightRange>>(
+    new Map(),
+  );
+  const [startPage, setStartPage] = useState<number | null>(null);
+  const [searchState, setSearchState] = useState<'idle' | 'searching' | 'found' | 'notfound'>(
+    'idle',
+  );
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const hasScrolledRef = useRef(false);
+  const scannedPagesRef = useRef<PageScan[] | null>(null);
+
+  // Escape key closes the modal.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  // Fetch chunk metadata (content + document title + PDF availability).
+  useEffect(() => {
+    let cancelled = false;
+    const apiPattern = window.apiUrls?.api_chunk_detail;
+    if (!apiPattern) {
+      setChunkError('Chunk detail API not configured.');
+      return;
+    }
+    const url = formatUrl(apiPattern, { chunk_id: chunkId });
+    fetch(url, { credentials: 'include' })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((data: ChunkDetail) => {
+        if (!cancelled) setChunk(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setChunkError(err.message || 'Failed to load chunk.');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [chunkId]);
+
+  // In parallel with the chunk fetch, ask the backend to LLM-narrow the
+  // citation to the most relevant verbatim quote.
+  useEffect(() => {
+    if (!messageUuid) {
+      setNarrowState('idle');
+      return;
+    }
+    const apiUrl = window.apiUrls?.api_citation_narrow;
+    if (!apiUrl) {
+      setNarrowState('idle');
+      return;
+    }
+    let cancelled = false;
+    setNarrowState('pending');
+    fetch(apiUrl, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCsrfCookie(),
+      },
+      body: JSON.stringify({ message_uuid: messageUuid, chunk_id: Number(chunkId) }),
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled) return;
+        const quote =
+          data && typeof data.quote === 'string' ? data.quote.trim() : '';
+        if (quote) {
+          setNarrowQuote(quote);
+          hasScrolledRef.current = false;
+          setNarrowState('tightened');
+        } else {
+          setNarrowState('failed');
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setNarrowState('failed');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [messageUuid, chunkId]);
+
+  const pdfUrl = useMemo(() => {
+    if (!window.pageUrls?.pdf) return null;
+    return formatUrl(window.pageUrls.pdf, { doc_id: docId });
+  }, [docId]);
+
+  const fallbackDocUrl = useMemo(() => {
+    if (!window.pageUrls?.document) return null;
+    return `${formatUrl(window.pageUrls.document, { doc_id: docId })}?chunk=${chunkId}`;
+  }, [docId, chunkId]);
+
+  const onDocumentLoad = useCallback((pdf: PDFDocumentProxy) => {
+    setPdfDoc(pdf);
+    setNumPages(pdf.numPages);
+  }, []);
+
+  // The panel is 640px wide; subtract scroll padding (p-4 = 16px each
+  // side) and a margin for the scrollbar so pages fit without horizontal
+  // overflow.
+  const pageWidth = 600;
+
+  // Scan all pages once, then run the locator. Cached in scannedPagesRef
+  // so the re-locate (after LLM narrow) doesn't re-fetch PDF text.
+  useEffect(() => {
+    if (!pdfDoc || !chunk || !chunk.content) return;
+    const queryText = narrowQuote ?? chunk.content;
+    let cancelled = false;
+    setSearchState('searching');
+
+    (async () => {
+      if (!scannedPagesRef.current) {
+        const pages: PageScan[] = [];
+        for (let p = 1; p <= pdfDoc.numPages; p++) {
+          const page = await pdfDoc.getPage(p);
+          // Compute the viewport at the same scale as the rendered canvas
+          // (react-pdf derives scale from the `width` prop in the same way).
+          const unscaled = page.getViewport({ scale: 1 });
+          const scale = pageWidth / unscaled.width;
+          const viewport = page.getViewport({ scale });
+          const tc = await page.getTextContent();
+          const items: PdfTextItem[] = [];
+          for (const it of tc.items) {
+            if (
+              'str' in it &&
+              typeof it.str === 'string' &&
+              'transform' in it &&
+              Array.isArray(it.transform)
+            ) {
+              items.push({
+                str: it.str,
+                transform: it.transform,
+                width: typeof it.width === 'number' ? it.width : 0,
+              });
+            }
+          }
+          pages.push({ pageNumber: p, items, viewport });
+          if (cancelled) return;
+        }
+        scannedPagesRef.current = pages;
+      }
+      // The locator only needs the strings.
+      const pagesForLocator = scannedPagesRef.current.map((s) => ({
+        pageNumber: s.pageNumber,
+        items: s.items,
+      }));
+      const match = locateAcrossDocument(pagesForLocator, queryText);
+      if (cancelled) return;
+      if (match) {
+        setPageHighlights(match.pageHighlights);
+        setStartPage(match.startPage);
+        setSearchState('found');
+      } else if (narrowQuote) {
+        const fullMatch = locateAcrossDocument(pagesForLocator, chunk.content);
+        if (fullMatch) {
+          setPageHighlights(fullMatch.pageHighlights);
+          setStartPage(fullMatch.startPage);
+          setSearchState('found');
+        } else {
+          setSearchState('notfound');
+        }
+      } else {
+        setSearchState('notfound');
+      }
+    })().catch(() => {
+      if (!cancelled) setSearchState('notfound');
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pdfDoc, chunk, narrowQuote, pageWidth]);
+
+  // Compute canvas-pixel rectangles for each highlighted item, using the
+  // item's PDF transform matrix and the page viewport. This bypasses the
+  // text-layer (whose span positions are based on fallback web-font
+  // metrics that drift a few px from where canvas glyphs are actually
+  // drawn).
+  const pageRects = useMemo(() => {
+    const out = new Map<number, HighlightRect[]>();
+    if (!scannedPagesRef.current) return out;
+    for (const scan of scannedPagesRef.current) {
+      const range = pageHighlights.get(scan.pageNumber);
+      if (!range) continue;
+      const rects: HighlightRect[] = [];
+      for (let i = range.firstItem; i <= range.lastItem; i++) {
+        const item = scan.items[i];
+        if (!item || !item.transform || item.transform.length < 6) continue;
+        const tx = item.transform;
+        // tx = [a, b, c, d, e, f]; (e, f) is the BASELINE of the text in
+        // PDF user space (origin bottom-left of the page).
+        // fontHeight in user space = sqrt(b^2 + d^2). For non-rotated
+        // text this collapses to |d|.
+        const fontHeight = Math.hypot(tx[1], tx[3]);
+        const widthUser = item.width;
+        const [baselineX, baselineY] = scan.viewport.convertToViewportPoint(tx[4], tx[5]);
+        const widthPx = widthUser * scan.viewport.scale;
+        const heightPx = fontHeight * scan.viewport.scale;
+        // Canvas Y axis points down; the baseline in viewport coords is
+        // already converted, so the top of the glyph row is baseline - height.
+        rects.push({
+          left: baselineX,
+          top: baselineY - heightPx,
+          width: widthPx,
+          height: heightPx,
+        });
+      }
+      out.set(scan.pageNumber, rects);
+    }
+    return out;
+  }, [pageHighlights]);
+
+  // After search finds a match, poll for the first highlight rect to
+  // mount in the DOM and scroll it into view.
+  useEffect(() => {
+    if (searchState !== 'found') return;
+    if (hasScrolledRef.current) return;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    let attempts = 0;
+    let timer: number | null = null;
+    const maxAttempts = 50; // ~5s at 100ms
+    const tick = () => {
+      attempts += 1;
+      const first = container.querySelector(`[${DATA_HIGHLIGHT_ATTR}]`);
+      if (first) {
+        (first as HTMLElement).scrollIntoView({ block: 'center', behavior: 'smooth' });
+        hasScrolledRef.current = true;
+        return;
+      }
+      if (attempts < maxAttempts) {
+        timer = window.setTimeout(tick, 100);
+      }
+    };
+    timer = window.setTimeout(tick, 100);
+    return () => {
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [searchState, pageRects]);
+
+  const renderBody = () => {
+    if (chunkError) {
+      return (
+        <div className="p-6 text-text-normal">
+          <p className="font-semibold mb-2">Couldn't load citation.</p>
+          <p className="text-sm text-text-low_contrast">{chunkError}</p>
+          {fallbackDocUrl && (
+            <a
+              href={fallbackDocUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 mt-3 text-accent hover:underline text-sm"
+            >
+              Open document page <ExternalLink className="w-3.5 h-3.5" />
+            </a>
+          )}
+        </div>
+      );
+    }
+
+    if (!chunk) {
+      return (
+        <div className="p-6 text-text-low_contrast text-sm">Loading citation…</div>
+      );
+    }
+
+    if (!chunk.document.has_pdf || !pdfUrl) {
+      return (
+        <div className="p-6 text-text-normal">
+          <p className="font-semibold mb-2">No PDF available for this document.</p>
+          <p className="text-sm text-text-low_contrast mb-3 whitespace-pre-wrap">
+            {chunk.content}
+          </p>
+          {fallbackDocUrl && (
+            <a
+              href={fallbackDocUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-accent hover:underline text-sm"
+            >
+              Open document page <ExternalLink className="w-3.5 h-3.5" />
+            </a>
+          )}
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex-1 min-h-0 flex flex-col">
+        {searchState === 'notfound' && (
+          <div className="px-4 py-2 bg-scheme-shade_4 border-b border-border-mid_contrast text-xs text-text-low_contrast">
+            Couldn't locate the cited passage in the PDF text layer.
+          </div>
+        )}
+        <div
+          ref={scrollContainerRef}
+          className="flex-1 min-h-0 overflow-auto bg-scheme-shade_5 flex flex-col items-center p-4 gap-4"
+        >
+          <Document
+            file={pdfUrl}
+            onLoadSuccess={onDocumentLoad}
+            loading={<div className="text-text-low_contrast text-sm py-8">Loading PDF…</div>}
+            error={
+              <div className="text-text-normal p-4">
+                <p className="font-semibold">Failed to load PDF.</p>
+                {fallbackDocUrl && (
+                  <a
+                    href={fallbackDocUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 mt-2 text-accent hover:underline text-sm"
+                  >
+                    Open document page <ExternalLink className="w-3.5 h-3.5" />
+                  </a>
+                )}
+              </div>
+            }
+          >
+            {Array.from({ length: numPages }, (_, i) => i + 1).map((pn) => {
+              const rects = pageRects.get(pn);
+              return (
+                <div key={pn} className="relative shadow-md">
+                  <Page
+                    pageNumber={pn}
+                    renderAnnotationLayer={false}
+                    width={pageWidth}
+                  />
+                  {rects && rects.length > 0 && (
+                    <div
+                      className="absolute inset-0 pointer-events-none"
+                      style={{ mixBlendMode: 'multiply' }}
+                    >
+                      {rects.map((r, i) => (
+                        <div
+                          key={i}
+                          {...{ [DATA_HIGHLIGHT_ATTR]: '' }}
+                          style={{
+                            position: 'absolute',
+                            left: r.left,
+                            top: r.top,
+                            width: r.width,
+                            height: r.height,
+                            backgroundColor: 'rgba(253, 224, 71, 0.55)',
+                            borderRadius: '2px',
+                          }}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </Document>
+        </div>
+      </div>
+    );
+  };
+
+  const headerStatus = useMemo(() => {
+    if (!chunk) return '';
+    if (searchState === 'searching') return ' · searching…';
+    if (searchState === 'notfound') return ' · passage not located';
+    if (searchState === 'found' && startPage) {
+      const pageList = Array.from(pageHighlights.keys()).sort((a, b) => a - b);
+      if (pageList.length === 0) return '';
+      const pageRange =
+        pageList.length === 1
+          ? `page ${pageList[0]}`
+          : `pages ${pageList[0]}–${pageList[pageList.length - 1]}`;
+      const narrowSuffix =
+        narrowState === 'pending'
+          ? ' · narrowing…'
+          : narrowState === 'tightened'
+            ? ' · tightened'
+            : '';
+      return ` · highlighted on ${pageRange}${narrowSuffix}`;
+    }
+    return '';
+  }, [chunk, searchState, startPage, pageHighlights, narrowState]);
+
+  // Slide-out panel: rendered inside CitationPanelSlot, sized by its
+  // parent (CITATION_PANEL_WIDTH). No backdrop / fixed positioning.
+  return (
+    <div className="bg-scheme-shade_3 h-full flex flex-col overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border-mid_contrast">
+        <div className="min-w-0">
+          <div className="text-text-normal font-semibold truncate">
+            {chunk?.document.title || 'PDF citation'}
+          </div>
+          {chunk && (
+            <div className="text-xs text-text-low_contrast">
+              Chunk {chunk.chunk_number}
+              {headerStatus}
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-1 flex-shrink-0">
+          {fallbackDocUrl && (
+            <a
+              href={fallbackDocUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open document page in new tab"
+              className="p-1 rounded hover:bg-scheme-shade_4 text-text-normal"
+            >
+              <ExternalLink className="w-4 h-4" />
+            </a>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close citation panel"
+            className="p-1 rounded hover:bg-scheme-shade_4 text-text-normal"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+      {renderBody()}
+    </div>
+  );
+};
+
+export default PDFCitationModal;

--- a/react/src/features/chat/components/TextCitationModal.tsx
+++ b/react/src/features/chat/components/TextCitationModal.tsx
@@ -1,0 +1,358 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { X, ExternalLink } from 'lucide-react';
+import formatUrl from '../../../utils/formatUrl';
+import { getCsrfCookie } from '../../../main';
+import type { CitationChunkDetail } from './citationTypes';
+
+interface TextCitationModalProps {
+  docId: string;
+  chunkId: string;
+  /** Assistant message UUID — enables LLM-narrowed highlight. */
+  messageUuid?: string;
+  /** Optional chunk prefetched by the provider, skipping the initial fetch. */
+  preloadedChunk?: CitationChunkDetail | null;
+  onClose: () => void;
+}
+
+/** Normalize whitespace and case for substring search so a quote that
+ *  differs only in collapsed spaces / smart quotes still matches. */
+function normalizeForSearch(s: string): string {
+  return s
+    .normalize('NFKC')
+    .replace(/[‘’‚‛]/g, "'")
+    .replace(/[“”„‟]/g, '"')
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+}
+
+/** Find `needle` inside `haystack` using normalized matching but return
+ *  an offset into the ORIGINAL haystack. Returns null on miss. */
+function findNormalizedOffset(haystack: string, needle: string): { start: number; end: number } | null {
+  const normNeedle = normalizeForSearch(needle).trim();
+  if (!normNeedle) return null;
+  // Build a parallel array of original-index per normalized character.
+  const indexMap: number[] = [];
+  let norm = '';
+  let prevWasSpace = false;
+  for (let i = 0; i < haystack.length; i++) {
+    const ch = haystack[i].normalize('NFKC');
+    for (const c of ch) {
+      let mapped = c;
+      if (c === '‘' || c === '’' || c === '‚' || c === '‛') mapped = "'";
+      else if (c === '“' || c === '”' || c === '„' || c === '‟') mapped = '"';
+      if (/\s/.test(mapped)) {
+        if (prevWasSpace) continue;
+        prevWasSpace = true;
+        norm += ' ';
+        indexMap.push(i);
+      } else {
+        prevWasSpace = false;
+        norm += mapped.toLowerCase();
+        indexMap.push(i);
+      }
+    }
+  }
+  const hit = norm.indexOf(normNeedle);
+  if (hit < 0) return null;
+  const start = indexMap[hit];
+  const endIdx = hit + normNeedle.length - 1;
+  if (endIdx >= indexMap.length) return null;
+  const end = indexMap[endIdx] + 1; // exclusive
+  return { start, end };
+}
+
+function formatTimestamp(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return `${m}:${r.toString().padStart(2, '0')}`;
+}
+
+export const TextCitationModal: React.FC<TextCitationModalProps> = ({
+  docId,
+  chunkId,
+  messageUuid,
+  preloadedChunk,
+  onClose,
+}) => {
+  const [chunk, setChunk] = useState<CitationChunkDetail | null>(preloadedChunk ?? null);
+  const [chunkError, setChunkError] = useState<string | null>(null);
+  const [narrowQuote, setNarrowQuote] = useState<string | null>(null);
+  const [narrowState, setNarrowState] = useState<'idle' | 'pending' | 'tightened' | 'failed'>('idle');
+
+  const markRef = useRef<HTMLSpanElement | null>(null);
+  const hasScrolledRef = useRef(false);
+
+  // Escape closes the panel.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  // Fetch chunk metadata if not preloaded.
+  useEffect(() => {
+    if (preloadedChunk) return;
+    let cancelled = false;
+    const apiPattern = window.apiUrls?.api_chunk_detail;
+    if (!apiPattern) {
+      setChunkError('Chunk detail API not configured.');
+      return;
+    }
+    const url = formatUrl(apiPattern, { chunk_id: chunkId });
+    fetch(url, { credentials: 'include' })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((data: CitationChunkDetail) => {
+        if (!cancelled) setChunk(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setChunkError(err.message || 'Failed to load chunk.');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [chunkId, preloadedChunk]);
+
+  // LLM-narrow in parallel.
+  useEffect(() => {
+    if (!messageUuid) {
+      setNarrowState('idle');
+      return;
+    }
+    const apiUrl = window.apiUrls?.api_citation_narrow;
+    if (!apiUrl) {
+      setNarrowState('idle');
+      return;
+    }
+    let cancelled = false;
+    setNarrowState('pending');
+    fetch(apiUrl, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCsrfCookie(),
+      },
+      body: JSON.stringify({ message_uuid: messageUuid, chunk_id: Number(chunkId) }),
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled) return;
+        const quote = data && typeof data.quote === 'string' ? data.quote.trim() : '';
+        if (quote) {
+          setNarrowQuote(quote);
+          hasScrolledRef.current = false;
+          setNarrowState('tightened');
+        } else {
+          setNarrowState('failed');
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setNarrowState('failed');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [messageUuid, chunkId]);
+
+  const fallbackDocUrl = useMemo(() => {
+    if (!window.pageUrls?.document) return null;
+    return `${formatUrl(window.pageUrls.document, { doc_id: docId })}?chunk=${chunkId}`;
+  }, [docId, chunkId]);
+
+  // Compute the highlight range within the displayed full_text. The API
+  // may have windowed full_text; subtract text_offset so positions line
+  // up with the local string.
+  const highlight = useMemo(() => {
+    if (!chunk) return null;
+    const text = chunk.document.full_text;
+    const localStart = chunk.start_position - chunk.document.text_offset;
+    const localEnd = chunk.end_position - chunk.document.text_offset;
+    const chunkStart = Math.max(0, Math.min(localStart, text.length));
+    const chunkEnd = Math.max(chunkStart, Math.min(localEnd, text.length));
+
+    let tightStart: number | null = null;
+    let tightEnd: number | null = null;
+    if (narrowQuote) {
+      const window_ = text.slice(chunkStart, chunkEnd);
+      const hit = findNormalizedOffset(window_, narrowQuote);
+      if (hit) {
+        tightStart = chunkStart + hit.start;
+        tightEnd = chunkStart + hit.end;
+      }
+    }
+    return { chunkStart, chunkEnd, tightStart, tightEnd };
+  }, [chunk, narrowQuote]);
+
+  // Scroll the highlight into view once it's in the DOM.
+  useEffect(() => {
+    if (!highlight) return;
+    if (hasScrolledRef.current) return;
+    let attempts = 0;
+    const maxAttempts = 30;
+    let timer: number | null = null;
+    const tick = () => {
+      attempts += 1;
+      if (markRef.current) {
+        markRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        hasScrolledRef.current = true;
+        return;
+      }
+      if (attempts < maxAttempts) {
+        timer = window.setTimeout(tick, 80);
+      }
+    };
+    timer = window.setTimeout(tick, 80);
+    return () => {
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [highlight, narrowQuote]);
+
+  const headerStatus = useMemo(() => {
+    if (!chunk) return '';
+    if (narrowState === 'pending') return ' · narrowing…';
+    if (narrowState === 'tightened') {
+      return highlight?.tightStart != null ? ' · tightened' : ' · narrow miss';
+    }
+    return '';
+  }, [chunk, narrowState, highlight]);
+
+  const renderBody = () => {
+    if (chunkError) {
+      return (
+        <div className="p-6 text-text-normal">
+          <p className="font-semibold mb-2">Couldn't load citation.</p>
+          <p className="text-sm text-text-low_contrast">{chunkError}</p>
+          {fallbackDocUrl && (
+            <a
+              href={fallbackDocUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 mt-3 text-accent hover:underline text-sm"
+            >
+              Open document page <ExternalLink className="w-3.5 h-3.5" />
+            </a>
+          )}
+        </div>
+      );
+    }
+
+    if (!chunk) {
+      return <div className="p-6 text-text-low_contrast text-sm">Loading citation…</div>;
+    }
+    if (!highlight) return null;
+
+    const text = chunk.document.full_text;
+    const { chunkStart, chunkEnd, tightStart, tightEnd } = highlight;
+
+    // Build the rendered segments. When narrowed, we nest a tighter
+    // <mark> inside the wider chunk highlight.
+    const before = text.slice(0, chunkStart);
+    const chunkText = text.slice(chunkStart, chunkEnd);
+    const after = text.slice(chunkEnd);
+
+    let chunkRendered: React.ReactNode;
+    if (tightStart != null && tightEnd != null) {
+      const relStart = tightStart - chunkStart;
+      const relEnd = tightEnd - chunkStart;
+      chunkRendered = (
+        <mark className="bg-yellow-200/40 text-inherit">
+          {chunkText.slice(0, relStart)}
+          <span
+            ref={markRef}
+            className="bg-yellow-300/80 text-inherit rounded-sm"
+            data-citation-hit=""
+          >
+            {chunkText.slice(relStart, relEnd)}
+          </span>
+          {chunkText.slice(relEnd)}
+        </mark>
+      );
+    } else {
+      chunkRendered = (
+        <mark
+          ref={markRef as unknown as React.RefObject<HTMLElement>}
+          className="bg-yellow-300/70 text-inherit rounded-sm"
+          data-citation-hit=""
+        >
+          {chunkText}
+        </mark>
+      );
+    }
+
+    return (
+      <div className="flex-1 min-h-0 overflow-auto bg-scheme-shade_5 p-4">
+        <pre className="whitespace-pre-wrap font-mono text-sm leading-relaxed text-text-normal">
+          {before}
+          {chunkRendered}
+          {after}
+        </pre>
+      </div>
+    );
+  };
+
+  const titleSuffix = useMemo(() => {
+    if (!chunk) return '';
+    if (chunk.start_time != null) return ` · ${formatTimestamp(chunk.start_time)}`;
+    return '';
+  }, [chunk]);
+
+  return (
+    <div className="bg-scheme-shade_3 h-full flex flex-col overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border-mid_contrast">
+        <div className="min-w-0">
+          <div className="text-text-normal font-semibold truncate">
+            {chunk?.document.title || 'Citation'}
+          </div>
+          {chunk && (
+            <div className="text-xs text-text-low_contrast truncate">
+              Chunk {chunk.chunk_number}
+              {titleSuffix}
+              {headerStatus}
+            </div>
+          )}
+          {chunk?.document.source_url && (
+            <a
+              href={chunk.document.source_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-accent hover:underline truncate inline-block max-w-full"
+              title={chunk.document.source_url}
+            >
+              {chunk.document.source_url}
+            </a>
+          )}
+        </div>
+        <div className="flex items-center gap-1 flex-shrink-0">
+          {fallbackDocUrl && (
+            <a
+              href={fallbackDocUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open document page in new tab"
+              className="p-1 rounded hover:bg-scheme-shade_4 text-text-normal"
+            >
+              <ExternalLink className="w-4 h-4" />
+            </a>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close citation panel"
+            className="p-1 rounded hover:bg-scheme-shade_4 text-text-normal"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+      {renderBody()}
+    </div>
+  );
+};
+
+export default TextCitationModal;

--- a/react/src/features/chat/components/citationTypes.ts
+++ b/react/src/features/chat/components/citationTypes.ts
@@ -1,0 +1,24 @@
+/** Response shape from `api_chunk_detail`. Shared between the PDF and
+ *  text citation modals (and the provider that prefetches it). */
+export interface CitationChunkDetail {
+  content: string;
+  chunk_number: number;
+  start_position: number;
+  end_position: number;
+  /** VTT transcript chunks carry the timestamp; null for everything else. */
+  start_time: number | null;
+  document: {
+    id: string;
+    title: string;
+    /** Django classname: PDFDocument, RawTextDocument, VTTDocument, … */
+    type: string;
+    /** True when the doc has a PDF (native, compiled, or crawl-rendered). */
+    has_pdf: boolean;
+    /** Origin URL for crawled webpages; null otherwise. */
+    source_url: string | null;
+    /** Full document text, possibly windowed around the chunk for very long docs. */
+    full_text: string;
+    /** When full_text is windowed, this is the character offset into the original full_text. */
+    text_offset: number;
+  };
+}

--- a/react/src/types/index.ts
+++ b/react/src/types/index.ts
@@ -45,5 +45,11 @@ declare global {
     pageUrls: {
       [key: string]: string;
     }
+    appFlags?: {
+      /** When true, the chat eagerly LLM-narrows every citation in newly
+       * arrived assistant messages so subsequent clicks open instantly. */
+      eagerCitationNarrow?: boolean;
+      [key: string]: unknown;
+    }
   }
 }

--- a/react/src/utils/linkifyRagCitations.ts
+++ b/react/src/utils/linkifyRagCitations.ts
@@ -1,7 +1,7 @@
 import formatUrl from './formatUrl';
 
 /** Matches RAG citation tokens like `[doc:<uuid> chunk:<id>]`. */
-const DOC_CHUNK_CITATION_RE =
+export const DOC_CHUNK_CITATION_RE =
   /\[doc:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\s+chunk:(\d+)\]/g;
 
 /**
@@ -15,12 +15,18 @@ export function linkifyRagCitations(content: string): string {
   const docPattern = window.pageUrls.document;
   return content.replace(DOC_CHUNK_CITATION_RE, (match, docId: string, chunkId: string) => {
     try {
+      // Keep the document-page URL as the anchor's href so modifier-click
+      // (ctrl/cmd/shift/middle) falls through to the native "open in new
+      // tab" behaviour. Plain clicks are intercepted by the chat-level
+      // delegate (see MessageBubble) and routed to the PDF citation modal.
       const href = `${formatUrl(docPattern, { doc_id: docId })}?chunk=${chunkId}`;
       return (
         `<a href="${href}" target="_blank" rel="noopener noreferrer" ` +
         `class="rag-citation-link inline-block rounded-md px-1.5 py-0.5 align-baseline ` +
         `border border-border-mid_contrast bg-scheme-shade_4 text-accent text-[0.9em] ` +
-        `no-underline hover:underline font-medium">[doc:${docId} chunk:${chunkId}]</a>`
+        `no-underline hover:underline font-medium cursor-pointer" ` +
+        `data-doc-id="${docId}" data-chunk-id="${chunkId}">` +
+        `[doc:${docId} chunk:${chunkId}]</a>`
       );
     } catch {
       return match;

--- a/react/src/utils/pdfTextMatch.ts
+++ b/react/src/utils/pdfTextMatch.ts
@@ -1,0 +1,390 @@
+/**
+ * Locate an LLM-supplied citation snippet inside a PDF.js text layer.
+ *
+ * Strategy:
+ *   1. Build three indexed views of the page's text-layer items:
+ *        - "tight"   = items joined with no separator (matches PDF text
+ *                      flow where pdfjs splits a sentence into adjacent
+ *                      items with no space between them)
+ *        - "spaced"  = items joined with a single space (matches PDF text
+ *                      flow where there is whitespace between items)
+ *        - "letters" = only [a-z0-9], for whitespace/punctuation drift
+ *      All normalised: NFKC, collapsed whitespace, smart quotes/dashes
+ *      unified to ASCII, soft hyphens stripped, lowercased.
+ *   2. Locate the chunk's *start anchor* (first ~150 chars) in the page.
+ *   3. Locate the chunk's *end anchor* (last ~150 chars) in the page,
+ *      searching from at-or-after the start anchor's items.
+ *   4. Return every item index in [start, end] inclusive — that's the
+ *      full extent of the chunk on this page.
+ *
+ * If only the start anchor matches, highlight just that anchor (chunk
+ * may span pages or partially fail to match further on).
+ */
+
+export interface PDFTextItemLike {
+  str: string;
+}
+
+export interface PDFMatchResult {
+  /** Indices into `items[]` that overlap the matched range. */
+  itemIndices: number[];
+}
+
+const SOFT_HYPHEN = '­';
+const SMART_QUOTES = /[‘’‚‛]/g;
+const SMART_DQUOTES = /[“”„‟]/g;
+const SMART_DASHES = /[‐‑‒–—―]/g;
+
+const MIN_ANCHOR_LEN = 20;
+const MAX_ANCHOR_LEN = 150;
+
+function normalise(s: string): string {
+  return s
+    .normalize('NFKC')
+    .replace(new RegExp(SOFT_HYPHEN, 'g'), '')
+    .replace(SMART_QUOTES, "'")
+    .replace(SMART_DQUOTES, '"')
+    .replace(SMART_DASHES, '-')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function lettersOnly(s: string): string {
+  return normalise(s).replace(/[^a-z0-9]+/g, '');
+}
+
+/** Pick the leading anchor: first N word-bounded chars of the query. */
+function pickStartAnchor(query: string): string {
+  const trimmed = query.trim();
+  if (trimmed.length <= MAX_ANCHOR_LEN) return trimmed;
+  const slice = trimmed.slice(0, MAX_ANCHOR_LEN);
+  const lastSpace = slice.lastIndexOf(' ');
+  return lastSpace > MAX_ANCHOR_LEN / 2 ? slice.slice(0, lastSpace) : slice;
+}
+
+/** Pick the trailing anchor: last N word-bounded chars of the query. */
+function pickEndAnchor(query: string): string {
+  const trimmed = query.trim();
+  if (trimmed.length <= MAX_ANCHOR_LEN) return trimmed;
+  const slice = trimmed.slice(trimmed.length - MAX_ANCHOR_LEN);
+  const firstSpace = slice.indexOf(' ');
+  return firstSpace >= 0 && firstSpace < MAX_ANCHOR_LEN / 2
+    ? slice.slice(firstSpace + 1)
+    : slice;
+}
+
+interface ItemRange {
+  start: number;
+  end: number;
+}
+
+interface PageIndex {
+  itemCount: number;
+  tightText: string;
+  tightRanges: ItemRange[];
+  spacedText: string;
+  spacedRanges: ItemRange[];
+  letters: string;
+  letterIdxToItem: number[];
+}
+
+function buildPageIndex(items: PDFTextItemLike[]): PageIndex {
+  const tightRanges: ItemRange[] = [];
+  const spacedRanges: ItemRange[] = [];
+  const letterIdxToItem: number[] = [];
+  let tight = '';
+  let spaced = '';
+  let letters = '';
+
+  for (let i = 0; i < items.length; i++) {
+    const piece = normalise(items[i].str);
+
+    const tightStart = tight.length;
+    tight += piece;
+    tightRanges.push({ start: tightStart, end: tight.length });
+
+    const spacedStart = spaced.length;
+    spaced += piece;
+    spacedRanges.push({ start: spacedStart, end: spaced.length });
+    if (i < items.length - 1) spaced += ' ';
+
+    const lettersPiece = piece.replace(/[^a-z0-9]+/g, '');
+    for (let k = 0; k < lettersPiece.length; k++) {
+      letters += lettersPiece[k];
+      letterIdxToItem.push(i);
+    }
+  }
+
+  return {
+    itemCount: items.length,
+    tightText: tight,
+    tightRanges,
+    spacedText: spaced,
+    spacedRanges,
+    letters,
+    letterIdxToItem,
+  };
+}
+
+interface AnchorMatch {
+  /** First item index covered by the match (0-indexed). */
+  firstItem: number;
+  /** Last item index covered by the match (0-indexed, inclusive). */
+  lastItem: number;
+}
+
+function rangeToItemSpan(ranges: ItemRange[], hitStart: number, hitEnd: number): AnchorMatch | null {
+  let first = -1;
+  let last = -1;
+  for (let i = 0; i < ranges.length; i++) {
+    const r = ranges[i];
+    if (r.start < hitEnd && r.end > hitStart) {
+      if (first === -1) first = i;
+      last = i;
+    }
+  }
+  return first === -1 ? null : { firstItem: first, lastItem: last };
+}
+
+/**
+ * Locate an anchor in a built PageIndex.
+ *
+ * `minItemIndex` lets the caller require the match to be at or after a
+ * particular item (useful for the end-anchor pass: find the second
+ * anchor at or after the start anchor's last item).
+ */
+function findAnchor(
+  idx: PageIndex,
+  rawAnchor: string,
+  minItemIndex = 0,
+): AnchorMatch | null {
+  const needle = normalise(rawAnchor);
+  if (needle.length < MIN_ANCHOR_LEN) return null;
+
+  // Compute starting offsets corresponding to minItemIndex.
+  const tightFrom = minItemIndex > 0 && minItemIndex < idx.tightRanges.length
+    ? idx.tightRanges[minItemIndex].start
+    : 0;
+  const spacedFrom = minItemIndex > 0 && minItemIndex < idx.spacedRanges.length
+    ? idx.spacedRanges[minItemIndex].start
+    : 0;
+
+  const tightHit = idx.tightText.indexOf(needle, tightFrom);
+  if (tightHit >= 0) {
+    const span = rangeToItemSpan(idx.tightRanges, tightHit, tightHit + needle.length);
+    if (span) return span;
+  }
+
+  const spacedHit = idx.spacedText.indexOf(needle, spacedFrom);
+  if (spacedHit >= 0) {
+    const span = rangeToItemSpan(idx.spacedRanges, spacedHit, spacedHit + needle.length);
+    if (span) return span;
+  }
+
+  // Letters-only fallback. Find the letters-onky position that corresponds
+  // to minItemIndex (first letterIdx whose mapped item >= minItemIndex).
+  const lettersNeedle = lettersOnly(rawAnchor);
+  if (lettersNeedle.length >= MIN_ANCHOR_LEN) {
+    let lettersFrom = 0;
+    if (minItemIndex > 0) {
+      while (lettersFrom < idx.letterIdxToItem.length && idx.letterIdxToItem[lettersFrom] < minItemIndex) {
+        lettersFrom++;
+      }
+    }
+    const lettersHit = idx.letters.indexOf(lettersNeedle, lettersFrom);
+    if (lettersHit >= 0) {
+      const first = idx.letterIdxToItem[lettersHit];
+      const last = idx.letterIdxToItem[lettersHit + lettersNeedle.length - 1];
+      if (first !== undefined && last !== undefined) {
+        return { firstItem: first, lastItem: last };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Try to locate `query` inside the text layer of one PDF page.
+ * Returns null if no match passes the length / fidelity gates.
+ *
+ * Implementation: dual-anchor matching. Anchors the first and last ~150
+ * chars of the query separately and highlights every item between (and
+ * including) them, so the full extent of the chunk is highlighted —
+ * not just the leading portion.
+ */
+export function locateInPage(
+  items: PDFTextItemLike[],
+  query: string,
+): PDFMatchResult | null {
+  if (items.length === 0) return null;
+  const trimmed = query.trim();
+  if (trimmed.length < MIN_ANCHOR_LEN) return null;
+
+  const idx = buildPageIndex(items);
+
+  const startAnchor = pickStartAnchor(trimmed);
+  const startMatch = findAnchor(idx, startAnchor);
+  if (!startMatch) return null;
+
+  // Short queries: start anchor already covers the whole thing.
+  if (trimmed.length <= MAX_ANCHOR_LEN) {
+    return collectItemIndices(startMatch.firstItem, startMatch.lastItem);
+  }
+
+  const endAnchor = pickEndAnchor(trimmed);
+  // Search for end anchor at or after the start anchor's last item.
+  const endMatch = findAnchor(idx, endAnchor, startMatch.lastItem);
+
+  const firstItem = startMatch.firstItem;
+  const lastItem = endMatch
+    ? Math.max(startMatch.lastItem, endMatch.lastItem)
+    : startMatch.lastItem;
+  return collectItemIndices(firstItem, lastItem);
+}
+
+export interface PageHighlightRange {
+  firstItem: number;
+  lastItem: number;
+}
+
+export interface DocumentMatchResult {
+  /** First page (1-indexed) that has any highlighted items — scroll target. */
+  startPage: number;
+  /** Map of pageNumber → inclusive item-index range to highlight on that page. */
+  pageHighlights: Map<number, PageHighlightRange>;
+}
+
+/**
+ * Locate a chunk across an entire document and return per-page highlight
+ * ranges. Handles the case where a chunk spans page boundaries:
+ *
+ *  - start page  → from startAnchor.firstItem through end of page items
+ *  - middle pages → every item
+ *  - end page    → from item 0 through endAnchor.lastItem
+ *  - single page → from startAnchor.firstItem through endAnchor.lastItem
+ *
+ * If only the start anchor matches (e.g. extraction drift), highlights
+ * extend to the end of the start page only.
+ */
+export function locateAcrossDocument(
+  pages: Array<{ pageNumber: number; items: PDFTextItemLike[] }>,
+  query: string,
+): DocumentMatchResult | null {
+  const trimmed = query.trim();
+  if (trimmed.length < MIN_ANCHOR_LEN) return null;
+
+  const indices = new Map<number, PageIndex>();
+  const getIdx = (pageNumber: number, items: PDFTextItemLike[]): PageIndex => {
+    let idx = indices.get(pageNumber);
+    if (!idx) {
+      idx = buildPageIndex(items);
+      indices.set(pageNumber, idx);
+    }
+    return idx;
+  };
+
+  const startAnchor = pickStartAnchor(trimmed);
+
+  let startInfo:
+    | { pageNumber: number; index: PageIndex; match: AnchorMatch }
+    | null = null;
+  for (const page of pages) {
+    const idx = getIdx(page.pageNumber, page.items);
+    const m = findAnchor(idx, startAnchor);
+    if (m) {
+      startInfo = { pageNumber: page.pageNumber, index: idx, match: m };
+      break;
+    }
+  }
+  if (!startInfo) return null;
+
+  const pageHighlights = new Map<number, PageHighlightRange>();
+
+  // Short query: anchor covers the whole chunk on one page.
+  if (trimmed.length <= MAX_ANCHOR_LEN) {
+    pageHighlights.set(startInfo.pageNumber, {
+      firstItem: startInfo.match.firstItem,
+      lastItem: startInfo.match.lastItem,
+    });
+    return { startPage: startInfo.pageNumber, pageHighlights };
+  }
+
+  const endAnchor = pickEndAnchor(trimmed);
+
+  let endInfo:
+    | { pageNumber: number; index: PageIndex; match: AnchorMatch }
+    | null = null;
+  for (const page of pages) {
+    if (page.pageNumber < startInfo.pageNumber) continue;
+    const idx = getIdx(page.pageNumber, page.items);
+    const minItem = page.pageNumber === startInfo.pageNumber ? startInfo.match.lastItem : 0;
+    const m = findAnchor(idx, endAnchor, minItem);
+    if (m) {
+      endInfo = { pageNumber: page.pageNumber, index: idx, match: m };
+      break;
+    }
+  }
+
+  if (!endInfo) {
+    // Couldn't find end anchor; highlight from start anchor through end of
+    // start page (chunk likely continues but we can't confirm where).
+    pageHighlights.set(startInfo.pageNumber, {
+      firstItem: startInfo.match.firstItem,
+      lastItem: startInfo.index.itemCount - 1,
+    });
+    return { startPage: startInfo.pageNumber, pageHighlights };
+  }
+
+  if (endInfo.pageNumber === startInfo.pageNumber) {
+    pageHighlights.set(startInfo.pageNumber, {
+      firstItem: startInfo.match.firstItem,
+      lastItem: Math.max(startInfo.match.lastItem, endInfo.match.lastItem),
+    });
+    return { startPage: startInfo.pageNumber, pageHighlights };
+  }
+
+  // Cross-page: highlight tail of start page, all of middle pages, head of end page.
+  pageHighlights.set(startInfo.pageNumber, {
+    firstItem: startInfo.match.firstItem,
+    lastItem: startInfo.index.itemCount - 1,
+  });
+  for (const page of pages) {
+    if (page.pageNumber > startInfo.pageNumber && page.pageNumber < endInfo.pageNumber) {
+      const idx = getIdx(page.pageNumber, page.items);
+      pageHighlights.set(page.pageNumber, {
+        firstItem: 0,
+        lastItem: idx.itemCount - 1,
+      });
+    }
+  }
+  pageHighlights.set(endInfo.pageNumber, {
+    firstItem: 0,
+    lastItem: endInfo.match.lastItem,
+  });
+
+  return { startPage: startInfo.pageNumber, pageHighlights };
+}
+
+function collectItemIndices(first: number, last: number): PDFMatchResult {
+  const itemIndices: number[] = [];
+  for (let i = first; i <= last; i++) itemIndices.push(i);
+  return { itemIndices };
+}
+
+/**
+ * Locate `query` across multiple pages' text contents. Returns the first
+ * page (1-indexed) that produces a match plus the matching item indices,
+ * or null if no page matches.
+ */
+export function locateInDocument(
+  pages: Array<{ pageNumber: number; items: PDFTextItemLike[] }>,
+  query: string,
+): { pageNumber: number; itemIndices: number[] } | null {
+  for (const page of pages) {
+    const m = locateInPage(page.items, query);
+    if (m) return { pageNumber: page.pageNumber, itemIndices: m.itemIndices };
+  }
+  return null;
+}

--- a/react/src/utils/pdfWorker.ts
+++ b/react/src/utils/pdfWorker.ts
@@ -1,0 +1,15 @@
+import { pdfjs } from 'react-pdf';
+
+// The worker file is copied to this static path by the `copy-pdf-worker`
+// Vite plugin (see vite.config.ts). A literal string is used instead of
+// Vite's `?url` import because that emits `import.meta.url`, which fails
+// to parse when the bundle is loaded as a non-module <script>.
+const WORKER_URL = '/static/js/dist/pdf.worker.min.mjs';
+
+let configured = false;
+
+export function configurePdfWorker(): void {
+  if (configured) return;
+  pdfjs.GlobalWorkerOptions.workerSrc = WORKER_URL;
+  configured = true;
+}

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -1,9 +1,50 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from "tailwindcss"
+import { copyFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Copy the pdfjs worker into the build output dir so it can be served by
+// Django's static handling at /static/js/dist/pdf.worker.min.mjs.
+// Done via plugin (not `import workerSrc from '...?url'`) to keep the
+// bundle free of `import.meta.url`, which would require <script type="module">.
+function copyPdfWorker(): Plugin {
+  return {
+    name: 'copy-pdf-worker',
+    apply: 'build',
+    closeBundle() {
+      const src = resolve(__dirname, 'node_modules/pdfjs-dist/build/pdf.worker.min.mjs')
+      const dest = resolve(__dirname, '../aquillm/aquillm/static/js/dist/pdf.worker.min.mjs')
+      mkdirSync(dirname(dest), { recursive: true })
+      copyFileSync(src, dest)
+    },
+  }
+}
+
+// IIFE format inlines CSS into the JS bundle (it injects <style> tags at
+// runtime via document.createElement("style")). But base.html still has a
+// <link rel="stylesheet" href="js/dist/main.css">. Write a placeholder so
+// that link doesn't 404. The actual styles live in main.js.
+function placeholderMainCss(): Plugin {
+  return {
+    name: 'placeholder-main-css',
+    apply: 'build',
+    closeBundle() {
+      const dest = resolve(__dirname, '../aquillm/aquillm/static/js/dist/main.css')
+      mkdirSync(dirname(dest), { recursive: true })
+      writeFileSync(
+        dest,
+        '/* CSS is bundled into main.js (IIFE format) and injected at runtime. */\n',
+      )
+    },
+  }
+}
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), copyPdfWorker(), placeholderMainCss()],
   base: '/static/js/dist/',
   build: {
     outDir: '../aquillm/aquillm/static/js/dist/',
@@ -14,6 +55,14 @@ export default defineConfig({
         main: './src/main.tsx',
       },
       output: {
+        // The bundle is loaded via a classic <script> tag in
+        // aquillm/templates/aquillm/base.html (not type="module"). IIFE
+        // emits a self-executing function with no `export` / `import.meta`
+        // syntax, so the file parses in that context. Rollup auto-rewrites
+        // `import.meta.url` to `document.currentScript.src` for IIFE,
+        // which keeps pdfjs-dist's internal usage working.
+        format: 'iife',
+        inlineDynamicImports: true,
         entryFileNames: '[name].js',
         chunkFileNames: '[name].js',
         assetFileNames: '[name].[ext]'


### PR DESCRIPTION
## Summary
Merges `feat/non-pdf-citation-modal` into `development`. `development` was already fully contained in this branch (the merge was a no-op), so this PR carries the feature work ahead of `development`:

- **Text citation modal** for non-PDF sources
- **PDF citation slide-out** with LLM-narrowed highlights
- **Crawl-time PDF capture** so citations can highlight on the original page layout — now gated off by default

## Crawl PDF capture is gated behind `CRAWL_CAPTURE_PDF` (default off)
PDF rendering during crawls is expensive (Selenium + CDP `printToPDF` per URL) and pulls in Chromium (~400MB). It is now opt-in at both layers:
- **Runtime:** per-URL capture is skipped unless `settings.CRAWL_CAPTURE_PDF` is set.
- **Build:** `Dockerfile.prod` installs `chromium`/`chromium-driver`/`fonts-liberation` only when `ARG CRAWL_CAPTURE_PDF` is truthy. The compose files wire this build arg from the `CRAWL_CAPTURE_PDF` env var, so one `.env` value controls both. Documented in `.env.example`.

Note: Chromium also backs the Selenium text-extraction fallback. With the flag off there is no system Chromium in prod — matching the pre-branch prod image, so no regression.

## Test plan
- [ ] Citation modals render for PDF and non-PDF sources in chat
- [ ] With `CRAWL_CAPTURE_PDF` unset: crawl succeeds, no PDF attached, default image builds without Chromium
- [ ] With `CRAWL_CAPTURE_PDF=1` (image built with the arg): crawl attaches a merged rendered PDF and the modal highlights on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)